### PR TITLE
perf(optimization): 8個の重いモーダルの遅延読み込み（next/dynamic）、SSR描画の最適化およびエフェクト省電力化

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,13 +21,6 @@ export default function Home() {
     }
   }, [currentTheme, isMounted])
 
-  // Hydration mismatch防止のためのプレースホルダー
-  if (!isMounted) {
-    return (
-      <div className="min-h-screen" style={{ backgroundColor: '#F3E5D8' }} />
-    )
-  }
-
   return (
     <div
       className={`min-h-screen bg-gradient-to-br ${themeConfig.gradient}`}

--- a/components/effects/FallingPetals.tsx
+++ b/components/effects/FallingPetals.tsx
@@ -72,8 +72,16 @@ export function FallingPetals({ count = 30, active = true }: FallingPetalsProps)
     }))
     const initialTimeout = setTimeout(() => setPetals(initialPetals), 0)
 
+    // バックグラウンドタブ時に生成を一時停止してCPU負荷を軽減
+    let isVisible = typeof document !== 'undefined' ? document.visibilityState === 'visible' : true
+    const handleVisibilityChange = () => {
+      isVisible = document.visibilityState === 'visible'
+    }
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+
     // Spawn petals mới liên tục
     const spawnInterval = setInterval(() => {
+      if (!isVisible) return
       setPetals(prev => {
         // Giới hạn số lượng tối đa
         if (prev.length >= count * 1.5) {
@@ -88,6 +96,7 @@ export function FallingPetals({ count = 30, active = true }: FallingPetalsProps)
 
     // Cleanup petals đã rơi xong
     const cleanupInterval = setInterval(() => {
+      if (!isVisible) return
       setPetals(prev => {
         const now = Date.now()
         return prev.filter(p => now - p.id < (p.duration + p.delay) * 1000 + 2000)
@@ -98,6 +107,7 @@ export function FallingPetals({ count = 30, active = true }: FallingPetalsProps)
       clearTimeout(initialTimeout)
       clearInterval(spawnInterval)
       clearInterval(cleanupInterval)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
     }
   }, [active, count, prefersReducedMotion])
 

--- a/components/effects/FallingSnow.tsx
+++ b/components/effects/FallingSnow.tsx
@@ -42,7 +42,14 @@ export function FallingSnow({ count = 50, active = true }: FallingSnowProps) {
     }))
     const initializationTimeout = setTimeout(() => setSnowflakes(initialSnow), 0)
 
+    let isVisible = typeof document !== 'undefined' ? document.visibilityState === 'visible' : true
+    const handleVisibilityChange = () => {
+      isVisible = document.visibilityState === 'visible'
+    }
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+
     const spawnInterval = setInterval(() => {
+      if (!isVisible) return
       setSnowflakes((previous) => {
         if (previous.length >= count * 1.8) return previous
         const newCount = 2 + Math.floor(Math.random() * 3)
@@ -51,6 +58,7 @@ export function FallingSnow({ count = 50, active = true }: FallingSnowProps) {
     }, 500)
 
     const cleanupInterval = setInterval(() => {
+      if (!isVisible) return
       setSnowflakes((previous) => {
         const now = Date.now()
         return previous.filter((snowflake) => (
@@ -63,6 +71,7 @@ export function FallingSnow({ count = 50, active = true }: FallingSnowProps) {
       clearTimeout(initializationTimeout)
       clearInterval(spawnInterval)
       clearInterval(cleanupInterval)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
     }
   }, [active, count, prefersReducedMotion])
 

--- a/components/effects/ParticleSystem.tsx
+++ b/components/effects/ParticleSystem.tsx
@@ -127,7 +127,9 @@ export default function ParticleSystem({
       window.addEventListener('mousemove', handleMouseMove)
     }
 
+    let isRunning = true
     const animate = () => {
+      if (!isRunning) return
       ctx.clearRect(0, 0, canvas.width, canvas.height)
 
       if (isActive) {
@@ -167,10 +169,29 @@ export default function ParticleSystem({
       animationRef.current = requestAnimationFrame(animate)
     }
 
+    // バックグラウンドタブ時にアニメーションループを一時停止
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        isRunning = false
+        if (animationRef.current) {
+          cancelAnimationFrame(animationRef.current)
+          animationRef.current = null
+        }
+      } else {
+        if (!isRunning) {
+          isRunning = true
+          animationRef.current = requestAnimationFrame(animate)
+        }
+      }
+    }
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+
     animate()
 
     return () => {
+      isRunning = false
       window.removeEventListener('resize', resizeCanvas)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
       if (followMouse) {
         window.removeEventListener('mousemove', handleMouseMove)
       }

--- a/components/ui/ModalManager.tsx
+++ b/components/ui/ModalManager.tsx
@@ -1,18 +1,70 @@
 'use client'
 
+import dynamic from 'next/dynamic'
 import { useUIStore } from '@/lib/stores/uiStore'
 import Modal from './Modal'
-import { MemoryGame } from '@/components/games/MemoryGame'
-import { PuzzleGame } from '@/components/games/PuzzleGame'
-import { BirthdayCalendar } from '@/components/games/BirthdayCalendar'
-import { BirthdayQuiz } from '@/components/games/BirthdayQuiz'
-import { PhotoGallery } from '@/components/features/PhotoGallery'
-import { MessageForm } from '@/components/community/MessageForm'
-import BulletinBoard from '@/components/community/BulletinBoard'
-import { ChatRoom } from '@/components/community/ChatRoom'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 
-import PhotoFrame from '@/components/features/PhotoFrame'
+// モーダル読み込み中のローディングスピナー
+function ModalLoadingSpinner() {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 gap-3">
+      <div
+        className="w-10 h-10 border-3 border-[#D4B08C]/30 border-t-[#854D27] rounded-full animate-spin"
+        style={{ animationDuration: '0.8s' }}
+      />
+      <span className="text-sm font-medium text-[#854D27]/80 tracking-wider">
+        Loading...
+      </span>
+    </div>
+  )
+}
+
+// 各モーダルコンポーネントを next/dynamic でコード分割し、初期バンドルサイズを大幅に削減
+const PhotoGallery = dynamic(
+  () => import('@/components/features/PhotoGallery').then((mod) => mod.PhotoGallery),
+  { ssr: false, loading: () => <ModalLoadingSpinner /> }
+)
+
+const PhotoFrame = dynamic(
+  () => import('@/components/features/PhotoFrame'),
+  { ssr: false, loading: () => <ModalLoadingSpinner /> }
+)
+
+const MessageForm = dynamic(
+  () => import('@/components/community/MessageForm').then((mod) => mod.MessageForm),
+  { ssr: false, loading: () => <ModalLoadingSpinner /> }
+)
+
+const BulletinBoard = dynamic(
+  () => import('@/components/community/BulletinBoard'),
+  { ssr: false, loading: () => <ModalLoadingSpinner /> }
+)
+
+const MemoryGame = dynamic(
+  () => import('@/components/games/MemoryGame').then((mod) => mod.MemoryGame),
+  { ssr: false, loading: () => <ModalLoadingSpinner /> }
+)
+
+const PuzzleGame = dynamic(
+  () => import('@/components/games/PuzzleGame').then((mod) => mod.PuzzleGame),
+  { ssr: false, loading: () => <ModalLoadingSpinner /> }
+)
+
+const BirthdayCalendar = dynamic(
+  () => import('@/components/games/BirthdayCalendar').then((mod) => mod.BirthdayCalendar),
+  { ssr: false, loading: () => <ModalLoadingSpinner /> }
+)
+
+const BirthdayQuiz = dynamic(
+  () => import('@/components/games/BirthdayQuiz').then((mod) => mod.BirthdayQuiz),
+  { ssr: false, loading: () => <ModalLoadingSpinner /> }
+)
+
+const ChatRoom = dynamic(
+  () => import('@/components/community/ChatRoom').then((mod) => mod.ChatRoom),
+  { ssr: false, loading: () => <ModalLoadingSpinner /> }
+)
 
 export function ModalManager() {
   const { activeModal, closeModal } = useUIStore()


### PR DESCRIPTION
## 概要

8個のモーダルコンポーネントを \
ext/dynamic\ により遅延読み込み化し、初期バンドルサイズを削減しました。あわせて \pp/page.tsx\ のクライアントブロッキングを解除して SSR 描画を最適化し、バックグラウンドタブ時のエフェクト省電力化を適用しました。

## Implementation
- [x] Implement #21 — 8個の重いモーダルの遅延読み込み、SSR描画最適化およびエフェクト省電力化

## Verification
- [x] 差分セルフレビュー完了
- [x] TypeScript 型チェックおよび Turbopack プロダクションビルド通過 (\
pm run build\)
- [x] Vitest テストスイート通過 (\
px vitest run __tests__/components __tests__/lib\)
- [x] \
ext/dynamic\ によるローディングスピナー表示と各モーダルのオンデマンド読み込み確認
- [x] バックグラウンドタブ時のエフェクト一時停止確認

## References
Closes #21

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lazily loads eight heavy modals with `next/dynamic`, unblocks SSR rendering on the home page, and pauses effect animations in background tabs to cut initial bundle size and CPU. Previously the modals were eagerly bundled, the page returned a mount-only placeholder, and effects ran continuously; now modals load on demand with a loading spinner and `ssr: false`, SSR content renders immediately, and effects pause when hidden and resume on visibility.

- Review notes
  - Modal loading: verify each modal opens/closes correctly, shows the loading spinner on first open, and that `ssr: false` does not break expected behavior.
  - SSR change: confirm no hydration mismatch or theme flicker after removing the isMounted placeholder in `app/page.tsx`.
  - Effects: check that petals/snow/particles pause in background tabs, resume on return, and do not leak timers/RAF. No API or import changes; no migration required.

<sup>Written for commit e4e078f5cb499cf0a642700334cb6e506b9936ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hayato-shino05/happy-birthday-website/pull/24?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

