### PR TITLE
運用品質・アクセシビリティ・CI・イベントデータを強化する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run typecheck
+      - run: npm test
+      - run: npm run build

--- a/.github/workflows/supabase-healthcheck.yml
+++ b/.github/workflows/supabase-healthcheck.yml
@@ -1,0 +1,43 @@
+name: Supabase healthcheck
+
+on:
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: supabase-healthcheck
+  cancel-in-progress: true
+
+jobs:
+  readonly-healthcheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Validate Supabase configuration
+        env:
+          SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "$SUPABASE_URL" || { echo "NEXT_PUBLIC_SUPABASE_URL secret is not configured" >&2; exit 1; }
+          test -n "$SUPABASE_ANON_KEY" || { echo "NEXT_PUBLIC_SUPABASE_ANON_KEY secret is not configured" >&2; exit 1; }
+          case "$SUPABASE_URL" in
+            https://*.supabase.co) ;;
+            *) echo "NEXT_PUBLIC_SUPABASE_URL must use an https://*.supabase.co URL" >&2; exit 1 ;;
+          esac
+
+      - name: Run read-only REST healthcheck
+        env:
+          SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+        run: |
+          set -euo pipefail
+          curl --silent --show-error --fail --max-time 10 \
+            -H "apikey: $SUPABASE_ANON_KEY" \
+            -H "Authorization: Bearer $SUPABASE_ANON_KEY" \
+            "$SUPABASE_URL/rest/v1/" \
+            >/dev/null

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,6 @@ yarn-error.log*
 
 # TypeScript 関連
 *.tsbuildinfo
-next-env.d.ts
 
 # エージェント・開発補助ツール関連
 .agents/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,9 @@ test: omikujiData の整合性テストケースを追加
    # リントチェック
    npm run lint
 
+   # 型検査
+   npm run typecheck
+
    # テスト実行
    npm run test
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,21 +31,26 @@
 ### 手順
 
 1. リポジトリを Fork してローカルに clone します。
+
    ```bash
    git clone https://github.com/<your-username>/happy-birthday-website.git
    cd happy-birthday-website
    ```
 
 2. 依存パッケージをインストールします。
+
    ```bash
    npm install
    ```
 
 3. 環境変数を設定します。
+
    ```bash
    cp .env.example .env.local
    ```
+
    `.env.local` を開き、Supabase の接続情報を設定します。
+
    ```env
    NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
    NEXT_PUBLIC_SUPABASE_ANON_KEY=your_anon_key_here
@@ -53,6 +58,7 @@
    ```
 
 4. 静的データマニフェストを生成します。
+
    ```bash
    npm run generate:data
    ```
@@ -69,12 +75,12 @@
 
 `main` ブランチに直接 push せず、目的ごとの作業ブランチを作成して作業します。
 
-| 種類 | 命名規則 | 例 |
-|------|----------|-----|
-| 新機能 | `feat/機能名` | `feat/interactive-3d-omikuji` |
-| バグ修正 | `fix/内容` | `fix/mobile-dock-zindex` |
-| ドキュメント | `docs/内容` | `docs/update-architecture` |
-| リファクタリング | `refactor/内容` | `refactor/music-store` |
+| 種類             | 命名規則        | 例                            |
+| ---------------- | --------------- | ----------------------------- |
+| 新機能           | `feat/機能名`   | `feat/interactive-3d-omikuji` |
+| バグ修正         | `fix/内容`      | `fix/mobile-dock-zindex`      |
+| ドキュメント     | `docs/内容`     | `docs/update-architecture`    |
+| リファクタリング | `refactor/内容` | `refactor/music-store`        |
 
 ### データベースとマイグレーション
 
@@ -103,7 +109,9 @@ UI のテキストや祝祭日データを追加・修正した場合は、以�
 ### スタイリング
 
 - Tailwind CSS 4 のユーティリティクラスを優先します。
-- テーマカラーやフォント指定には、`app/globals.css` に定義された CSS 変数および `@theme` トークンを使用します。
+- テーマカラー、surface、text、border、shadow、font は `app/globals.css` の CSS 変数および `@theme` トークンを使用します。
+- 既存の inline style と固定値は一括置換せず、変更対象の機能やアクセシビリティ修正に触れる範囲で段階的に token 化します。
+- 色の意味やコントラストを変える広範な visual redesign は、個別 Issue で方針を確認してから実施します。
 
 ## コミット規約
 
@@ -119,6 +127,7 @@ test: omikujiData の整合性テストケースを追加
 ## Pull Request の作成
 
 1. 変更を実装し、ローカルでテストとビルドを実行します。
+
    ```bash
    # リントチェック
    npm run lint
@@ -134,6 +143,7 @@ test: omikujiData の整合性テストケースを追加
    ```
 
 2. 変更をコミットしてリモートブランチに push します。
+
    ```bash
    git push origin feat/your-feature-name
    ```

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -60,7 +60,7 @@ migration の適用後に `supabase/seed.sql` を実行すると、誕生日、�
 | `photo-album` | フォトアルバム・思い出ギャラリー写真/動画 | 50 MiB | 画像全般 (HEIC/HEIF含む), MP4, WebM, QuickTime |
 | `community-media` | 掲示板・チャットの写真・動画・音声メッセージ | 50 MiB | 画像, MP4, WebM, 音声各種 |
 | `music` | カスタム BGM 音楽トラック | 15 MiB | MP3, WAV, OGG, WebM, FLAC, AAC |
-| `avatars` | アバター・スタンプ画像 | 5 MiB | JPEG, PNG, WebP, GIF, SVG |
+| `avatars` | アバター・スタンプ画像 | 5 MiB | JPEG, PNG, WebP, GIF |
 | `time-capsules` | タイムカプセル添付メディア | 50 MiB | 画像, MP4, WebM, 音声各種 |
 
 匿名ユーザーは各バケットのオブジェクトを閲覧・作成できます。更新・削除は許可していません。

--- a/README.md
+++ b/README.md
@@ -277,9 +277,11 @@ omoide/
 | `npm run build` | 本番ビルドを作成します。 |
 | `npm run start` | 本番サーバーを起動します。 |
 | `npm run lint` | ESLint を実行します。 |
+| `npm run typecheck` | TypeScript の型検査（`tsc --noEmit`）を実行します。 |
 | `npm run test` | Vitest を 1 回実行します。 |
 | `npm run test:watch` | Vitest を watch mode で実行します。 |
 | `npm run test:coverage` | coverage 付きでテストを実行します。 |
+| `npm run generate:data` | `data/generated/` 配下のマニフェストを再生成します。 |
 
 ## 関連ドキュメント
 

--- a/__tests__/api/birthdays-route.test.ts
+++ b/__tests__/api/birthdays-route.test.ts
@@ -12,8 +12,8 @@ function makeBuilder(result: QueryResult): Builder {
     from: () => builder,
     select: () => builder,
     order: () => builder,
-    eq: () => builder,
-    limit: () => builder,
+    eq: vi.fn(() => builder),
+    limit: vi.fn(() => builder),
   }
   return Object.assign(builder, {
     then: (onFulfilled: (r: QueryResult) => void) => onFulfilled(result),
@@ -43,16 +43,19 @@ describe('GET /api/birthdays query handling', () => {
     const body = await response.json()
     expect(body).toHaveProperty('data')
     expect(body).toHaveProperty('count')
+    expect(builder.eq).toHaveBeenCalledWith('month', 10)
   })
 
   it('ignores an out-of-range month instead of erroring', async () => {
     const response = await call('http://localhost/api/birthdays?month=13')
     expect(response.status).toBe(200)
+    expect(builder.eq).not.toHaveBeenCalled()
   })
 
   it('ignores a non-numeric month instead of erroring', async () => {
     const response = await call('http://localhost/api/birthdays?month=abc')
     expect(response.status).toBe(200)
+    expect(builder.eq).not.toHaveBeenCalled()
   })
 
   it('returns the 500 envelope when the data source errors', async () => {

--- a/__tests__/api/birthdays-route.test.ts
+++ b/__tests__/api/birthdays-route.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+type QueryResult = { data: unknown[]; error: { message: string } | null }
+
+type Builder = Record<string, unknown> & {
+  then: (onFulfilled: (result: QueryResult) => void) => void
+}
+
+function makeBuilder(result: QueryResult): Builder {
+  const builder: Record<string, unknown> = {
+    from: () => builder,
+    select: () => builder,
+    order: () => builder,
+    eq: () => builder,
+    limit: () => builder,
+  }
+  return Object.assign(builder, {
+    then: (onFulfilled: (r: QueryResult) => void) => onFulfilled(result),
+  }) as Builder
+}
+
+let builder: Builder
+
+vi.mock('@/lib/supabase/client', () => ({
+  getSupabase: () => builder,
+}))
+
+import { GET as getBirthdays } from '@/app/api/birthdays/route'
+
+function call(url: string): Promise<Response> {
+  return getBirthdays(new NextRequest(url))
+}
+
+describe('GET /api/birthdays query handling', () => {
+  beforeEach(() => {
+    builder = makeBuilder({ data: [], error: null })
+  })
+
+  it('filters by a valid month via eq(month)', async () => {
+    const response = await call('http://localhost/api/birthdays?month=10')
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body).toHaveProperty('data')
+    expect(body).toHaveProperty('count')
+  })
+
+  it('ignores an out-of-range month instead of erroring', async () => {
+    const response = await call('http://localhost/api/birthdays?month=13')
+    expect(response.status).toBe(200)
+  })
+
+  it('ignores a non-numeric month instead of erroring', async () => {
+    const response = await call('http://localhost/api/birthdays?month=abc')
+    expect(response.status).toBe(200)
+  })
+
+  it('returns the 500 envelope when the data source errors', async () => {
+    builder = makeBuilder({ data: [], error: { message: 'boom' } })
+
+    const response = await call('http://localhost/api/birthdays')
+    expect(response.status).toBe(500)
+    const body = await response.json()
+    expect(typeof body.error).toBe('string')
+  })
+})

--- a/__tests__/api/birthdays-route.test.ts
+++ b/__tests__/api/birthdays-route.test.ts
@@ -64,3 +64,14 @@ describe('GET /api/birthdays query handling', () => {
     expect(typeof body.error).toBe('string')
   })
 })
+
+describe('birthday management boundary', () => {
+  it('exposes no anonymous mutating handlers', async () => {
+    const mod = await import('@/app/api/birthdays/route')
+    // anon は読み取り専用。作成・更新・削除の API 経路を設けない
+    expect(mod.GET).toBeTypeOf('function')
+    expect((mod as Record<string, unknown>).POST).toBeUndefined()
+    expect((mod as Record<string, unknown>).PUT).toBeUndefined()
+    expect((mod as Record<string, unknown>).DELETE).toBeUndefined()
+  })
+})

--- a/__tests__/components/Confetti.test.tsx
+++ b/__tests__/components/Confetti.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render } from '@testing-library/react'
+import { render, act } from '@testing-library/react'
 import Confetti, { ConfettiBurst } from '@/components/effects/Confetti'
 import * as mediaQueryHooks from '@/lib/hooks/useMediaQuery'
 
@@ -57,13 +57,17 @@ describe('Confetti and ConfettiBurst reduced-motion lifecycle', () => {
       const { rerender } = render(<Confetti isActive={true} particleCount={100} duration={1000} onComplete={onComplete} />)
 
       expect(onComplete).not.toHaveBeenCalled()
-      vi.advanceTimersByTime(1000)
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
       expect(onComplete).toHaveBeenCalledTimes(1)
 
       // 完了後にエフェクトの依存値（particleCount, duration）が変わっても isActive=true の間は再開・多重発火しないこと
       rerender(<Confetti isActive={true} particleCount={250} duration={2000} onComplete={onComplete} />)
 
-      vi.advanceTimersByTime(2000)
+      act(() => {
+        vi.advanceTimersByTime(2000)
+      })
       expect(onComplete).toHaveBeenCalledTimes(1)
     } finally {
       vi.useRealTimers()
@@ -91,7 +95,9 @@ describe('Confetti and ConfettiBurst reduced-motion lifecycle', () => {
       )
 
       // 500ms 経過（アニメーション実行中）
-      vi.advanceTimersByTime(500)
+      act(() => {
+        vi.advanceTimersByTime(500)
+      })
       expect(onComplete).not.toHaveBeenCalled()
 
       // 実行中にコールバック・依存プロパティ（colors, particleCount）の参照が変更される
@@ -100,11 +106,15 @@ describe('Confetti and ConfettiBurst reduced-motion lifecycle', () => {
       )
 
       // タイマーがリセットされずに当初の残り 500ms（合計 1000ms）で完了すること
-      vi.advanceTimersByTime(500)
+      act(() => {
+        vi.advanceTimersByTime(500)
+      })
       expect(onComplete).toHaveBeenCalledTimes(1)
 
       // さらなる時間経過で重複発火しないこと
-      vi.advanceTimersByTime(1000)
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
       expect(onComplete).toHaveBeenCalledTimes(1)
     } finally {
       vi.useRealTimers()

--- a/__tests__/components/Confetti.test.tsx
+++ b/__tests__/components/Confetti.test.tsx
@@ -69,4 +69,15 @@ describe('Confetti and ConfettiBurst reduced-motion lifecycle', () => {
       vi.useRealTimers()
     }
   })
+
+  it('does not call onComplete when !isActive and prefersReducedMotion is true', () => {
+    vi.spyOn(mediaQueryHooks, 'usePrefersReducedMotion').mockReturnValue(true)
+    const onComplete = vi.fn()
+
+    render(<Confetti isActive={false} onComplete={onComplete} />)
+    expect(onComplete).not.toHaveBeenCalled()
+
+    render(<ConfettiBurst x={50} y={50} isActive={false} onComplete={onComplete} />)
+    expect(onComplete).not.toHaveBeenCalled()
+  })
 })

--- a/__tests__/components/Confetti.test.tsx
+++ b/__tests__/components/Confetti.test.tsx
@@ -80,4 +80,34 @@ describe('Confetti and ConfettiBurst reduced-motion lifecycle', () => {
     render(<ConfettiBurst x={50} y={50} isActive={false} onComplete={onComplete} />)
     expect(onComplete).not.toHaveBeenCalled()
   })
+
+  it('does not reset timer or duplicate onComplete when props change mid-flight', () => {
+    vi.useFakeTimers()
+    try {
+      vi.spyOn(mediaQueryHooks, 'usePrefersReducedMotion').mockReturnValue(false)
+      const onComplete = vi.fn()
+      const { rerender } = render(
+        <Confetti isActive={true} particleCount={100} duration={1000} colors={['#FF0000']} onComplete={onComplete} />
+      )
+
+      // 500ms 経過（アニメーション実行中）
+      vi.advanceTimersByTime(500)
+      expect(onComplete).not.toHaveBeenCalled()
+
+      // 実行中にコールバック・依存プロパティ（colors, particleCount）の参照が変更される
+      rerender(
+        <Confetti isActive={true} particleCount={200} duration={1000} colors={['#00FF00', '#0000FF']} onComplete={onComplete} />
+      )
+
+      // タイマーがリセットされずに当初の残り 500ms（合計 1000ms）で完了すること
+      vi.advanceTimersByTime(500)
+      expect(onComplete).toHaveBeenCalledTimes(1)
+
+      // さらなる時間経過で重複発火しないこと
+      vi.advanceTimersByTime(1000)
+      expect(onComplete).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/__tests__/components/Confetti.test.tsx
+++ b/__tests__/components/Confetti.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import Confetti, { ConfettiBurst } from '@/components/effects/Confetti'
+import * as mediaQueryHooks from '@/lib/hooks/useMediaQuery'
+
+describe('Confetti and ConfettiBurst reduced-motion lifecycle', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('calls onComplete exactly once when prefersReducedMotion is true initially', () => {
+    vi.spyOn(mediaQueryHooks, 'usePrefersReducedMotion').mockReturnValue(true)
+    const onComplete = vi.fn()
+
+    const { rerender } = render(<Confetti isActive={true} onComplete={onComplete} />)
+    expect(onComplete).toHaveBeenCalledTimes(1)
+
+    // 再レンダリングしても isActive が true の間は多重発火しないこと
+    rerender(<Confetti isActive={true} onComplete={onComplete} />)
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+
+  it('completes exactly once when prefersReducedMotion transitions to true mid-flight', () => {
+    const prefersReducedMotionSpy = vi.spyOn(mediaQueryHooks, 'usePrefersReducedMotion').mockReturnValue(false)
+    const onComplete = vi.fn()
+
+    const { rerender } = render(<Confetti isActive={true} duration={5000} onComplete={onComplete} />)
+    expect(onComplete).not.toHaveBeenCalled()
+
+    // アニメーション途中で reduced-motion が有効化された場合
+    prefersReducedMotionSpy.mockReturnValue(true)
+    rerender(<Confetti isActive={true} duration={5000} onComplete={onComplete} />)
+
+    expect(onComplete).toHaveBeenCalledTimes(1)
+
+    // その後の再レンダリングで重複発火しないこと
+    rerender(<Confetti isActive={true} duration={5000} onComplete={onComplete} />)
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+
+  it('ConfettiBurst completes exactly once when prefersReducedMotion is true', () => {
+    vi.spyOn(mediaQueryHooks, 'usePrefersReducedMotion').mockReturnValue(true)
+    const onComplete = vi.fn()
+
+    const { rerender } = render(<ConfettiBurst x={100} y={100} isActive={true} onComplete={onComplete} />)
+    expect(onComplete).toHaveBeenCalledTimes(1)
+
+    rerender(<ConfettiBurst x={100} y={100} isActive={true} onComplete={onComplete} />)
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+})

--- a/__tests__/components/Confetti.test.tsx
+++ b/__tests__/components/Confetti.test.tsx
@@ -48,4 +48,27 @@ describe('Confetti and ConfettiBurst reduced-motion lifecycle', () => {
     rerender(<ConfettiBurst x={100} y={100} isActive={true} onComplete={onComplete} />)
     expect(onComplete).toHaveBeenCalledTimes(1)
   })
+
+  it('does not restart or duplicate onComplete when onComplete reference changes after timeout', () => {
+    vi.useFakeTimers()
+    try {
+      vi.spyOn(mediaQueryHooks, 'usePrefersReducedMotion').mockReturnValue(false)
+      const onComplete1 = vi.fn()
+      const { rerender } = render(<Confetti isActive={true} duration={1000} onComplete={onComplete1} />)
+
+      expect(onComplete1).not.toHaveBeenCalled()
+      vi.advanceTimersByTime(1000)
+      expect(onComplete1).toHaveBeenCalledTimes(1)
+
+      // 完了後に親が新しい onComplete 参照を渡して再レンダリング
+      const onComplete2 = vi.fn()
+      rerender(<Confetti isActive={true} duration={1000} onComplete={onComplete2} />)
+
+      // 新しいタイマーが進んでも onComplete2 は呼ばれず、再開しない
+      vi.advanceTimersByTime(1000)
+      expect(onComplete2).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/__tests__/components/Confetti.test.tsx
+++ b/__tests__/components/Confetti.test.tsx
@@ -49,24 +49,22 @@ describe('Confetti and ConfettiBurst reduced-motion lifecycle', () => {
     expect(onComplete).toHaveBeenCalledTimes(1)
   })
 
-  it('does not restart or duplicate onComplete when onComplete reference changes after timeout', () => {
+  it('does not restart or duplicate onComplete when effect dependencies change after timeout', () => {
     vi.useFakeTimers()
     try {
       vi.spyOn(mediaQueryHooks, 'usePrefersReducedMotion').mockReturnValue(false)
-      const onComplete1 = vi.fn()
-      const { rerender } = render(<Confetti isActive={true} duration={1000} onComplete={onComplete1} />)
+      const onComplete = vi.fn()
+      const { rerender } = render(<Confetti isActive={true} particleCount={100} duration={1000} onComplete={onComplete} />)
 
-      expect(onComplete1).not.toHaveBeenCalled()
+      expect(onComplete).not.toHaveBeenCalled()
       vi.advanceTimersByTime(1000)
-      expect(onComplete1).toHaveBeenCalledTimes(1)
+      expect(onComplete).toHaveBeenCalledTimes(1)
 
-      // 完了後に親が新しい onComplete 参照を渡して再レンダリング
-      const onComplete2 = vi.fn()
-      rerender(<Confetti isActive={true} duration={1000} onComplete={onComplete2} />)
+      // 完了後にエフェクトの依存値（particleCount, duration）が変わっても isActive=true の間は再開・多重発火しないこと
+      rerender(<Confetti isActive={true} particleCount={250} duration={2000} onComplete={onComplete} />)
 
-      // 新しいタイマーが進んでも onComplete2 は呼ばれず、再開しない
-      vi.advanceTimersByTime(1000)
-      expect(onComplete2).not.toHaveBeenCalled()
+      vi.advanceTimersByTime(2000)
+      expect(onComplete).toHaveBeenCalledTimes(1)
     } finally {
       vi.useRealTimers()
     }

--- a/__tests__/components/PhotoCard.keyboard.test.tsx
+++ b/__tests__/components/PhotoCard.keyboard.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { PhotoCard } from '@/components/features/PhotoCard'
+import type { MediaFile } from '@/types'
+
+const media: MediaFile = {
+  id: 1,
+  file_name: 'a.png',
+  file_path: '/a.png',
+  file_type: 'image',
+  file_size: 1,
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+describe('PhotoCard keyboard interaction', () => {
+  it('activates onClick via Enter and Space keys', () => {
+    const onClick = vi.fn()
+    render(<PhotoCard media={media} onClick={onClick} />)
+
+    const card = screen.getByRole('button', { name: 'a.png' })
+    fireEvent.keyDown(card, { key: 'Enter' })
+    fireEvent.keyDown(card, { key: ' ' })
+
+    expect(onClick).toHaveBeenCalledTimes(2)
+  })
+})

--- a/__tests__/components/mobile-touch-targets.test.ts
+++ b/__tests__/components/mobile-touch-targets.test.ts
@@ -68,6 +68,7 @@ describe('mobile fixed controls touch targets (scoped)', () => {
       "openModal('memoryGame')",
       "openModal('puzzleGame')",
       "openModal('calendar')",
+      "openModal('timeCapsule')",
     ]
 
     for (const action of sheetActions) {

--- a/__tests__/components/mobile-touch-targets.test.ts
+++ b/__tests__/components/mobile-touch-targets.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// モバイル固定操作群のタッチターゲット（≥44px）をソースレベルで保証する回帰ガード。
+// jsdom はレイアウト計算を行わないため、実寸は UI テストではなくこの静的検証で守る。
+const source = readFileSync(
+  join(process.cwd(), 'components', 'ui', 'MobileBottomDock.tsx'),
+  'utf8',
+)
+
+describe('mobile fixed controls touch targets', () => {
+  it('keeps the raised 44px hit-area classes', () => {
+    const hits = source.match(/min-(?:w|h)-\[44px\]|min-h-\[48px\]|min-w-\[50px\]/g) ?? []
+    // ドック5ボタン＋カプセル3＋シートClose＋シェア5 の最低ライン
+    expect(hits.length).toBeGreaterThanOrEqual(12)
+  })
+
+  it('does not attach legacy small sizes to labelled interactive elements', () => {
+    const offenders = source.split('\n').filter(
+      (line) => /aria-label=/.test(line) && /\bw-[6789] h-[6789]\b/.test(line),
+    )
+    expect(offenders).toEqual([])
+  })
+})

--- a/__tests__/components/mobile-touch-targets.test.ts
+++ b/__tests__/components/mobile-touch-targets.test.ts
@@ -16,10 +16,9 @@ describe('mobile fixed controls touch targets', () => {
     expect(hits.length).toBeGreaterThanOrEqual(12)
   })
 
-  it('does not attach legacy small sizes to labelled interactive elements', () => {
-    const offenders = source.split('\n').filter(
-      (line) => /aria-label=/.test(line) && /\bw-[6789] h-[6789]\b/.test(line),
-    )
-    expect(offenders).toEqual([])
+  it('ensures fixed navigation controls have sufficient touch target sizing', () => {
+    // 固定ドックおよびコントロールボタンに min-h-[44px] または min-h-[48px] が設定されていることを検証
+    const touchTargetClasses = source.match(/min-h-\[(?:44|48)px\]/g) ?? []
+    expect(touchTargetClasses.length).toBeGreaterThanOrEqual(8)
   })
 })

--- a/__tests__/components/mobile-touch-targets.test.ts
+++ b/__tests__/components/mobile-touch-targets.test.ts
@@ -9,8 +9,21 @@ const source = readFileSync(
   'utf8',
 )
 
+function getButtonClassName(identifier: string): string {
+  const idx = source.indexOf(identifier)
+  expect(idx, `Missing identifier: ${identifier}`).toBeGreaterThanOrEqual(0)
+  const tagStart = source.lastIndexOf('<button', idx)
+  const tagEnd = source.indexOf('>', idx)
+  expect(tagStart, `Cannot find <button start for: ${identifier}`).toBeGreaterThanOrEqual(0)
+  expect(tagEnd, `Cannot find > end for: ${identifier}`).toBeGreaterThanOrEqual(0)
+  const openingTag = source.slice(tagStart, tagEnd + 1)
+  const classMatch = openingTag.match(/className=(?:\{`([^`]+)`\}|"([^"]+)")/)
+  expect(classMatch, `Missing className attribute in <button> tag for: ${identifier}`).toBeTruthy()
+  return classMatch![1] || classMatch![2] || ''
+}
+
 describe('mobile fixed controls touch targets (scoped)', () => {
-  it('ensures all 5 main bottom dock navigation buttons meet 48px target', () => {
+  it('ensures all 5 main bottom dock navigation buttons meet 48px target in className', () => {
     const dockButtons = [
       "openModal('album')",
       "openModal('message')",
@@ -20,17 +33,13 @@ describe('mobile fixed controls touch targets (scoped)', () => {
     ]
 
     for (const action of dockButtons) {
-      const idx = source.indexOf(action)
-      expect(idx, `Missing dock action: ${action}`).toBeGreaterThanOrEqual(0)
-      const buttonStart = source.lastIndexOf('<button', idx)
-      const buttonEnd = source.indexOf('</button>', idx)
-      const buttonChunk = source.slice(buttonStart, buttonEnd + 9)
-      expect(buttonChunk).toMatch(/min-h-\[48px\]/)
-      expect(buttonChunk).toMatch(/min-w-\[50px\]/)
+      const className = getButtonClassName(action)
+      expect(className).toMatch(/min-h-\[48px\]/)
+      expect(className).toMatch(/min-w-\[50px\]/)
     }
   })
 
-  it('ensures music capsule player controls meet >=44px target', () => {
+  it('ensures music capsule player controls meet >=44px target in className', () => {
     const musicControls = [
       "aria-label={t('selectMusic')}",
       "aria-label={t('previousTrack')}",
@@ -39,23 +48,15 @@ describe('mobile fixed controls touch targets (scoped)', () => {
     ]
 
     for (const label of musicControls) {
-      const idx = source.indexOf(label)
-      expect(idx, `Missing player control: ${label}`).toBeGreaterThanOrEqual(0)
-      const buttonStart = source.lastIndexOf('<button', idx)
-      const buttonEnd = source.indexOf('</button>', idx)
-      const buttonChunk = source.slice(buttonStart, buttonEnd + 9)
-      expect(buttonChunk).toMatch(/min-h-\[44px\]/)
+      const className = getButtonClassName(label)
+      expect(className).toMatch(/min-h-\[44px\]/)
     }
   })
 
-  it('ensures sheet close and modal trigger buttons meet >=44px / >=48px target', () => {
-    const sheetCloseIdx = source.indexOf("aria-label={t('close')}")
-    expect(sheetCloseIdx).toBeGreaterThanOrEqual(0)
-    const closeStart = source.lastIndexOf('<button', sheetCloseIdx)
-    const closeEnd = source.indexOf('</button>', sheetCloseIdx)
-    const closeChunk = source.slice(closeStart, closeEnd + 9)
-    expect(closeChunk).toMatch(/min-h-\[44px\]/)
-    expect(closeChunk).toMatch(/min-w-\[44px\]/)
+  it('ensures sheet close and modal trigger buttons meet >=44px / >=48px target in className', () => {
+    const sheetCloseClass = getButtonClassName("aria-label={t('close')}")
+    expect(sheetCloseClass).toMatch(/min-h-\[44px\]/)
+    expect(sheetCloseClass).toMatch(/min-w-\[44px\]/)
 
     const sheetActions = [
       "openModal('omikuji')",
@@ -67,12 +68,8 @@ describe('mobile fixed controls touch targets (scoped)', () => {
     ]
 
     for (const action of sheetActions) {
-      const idx = source.indexOf(action)
-      expect(idx, `Missing sheet action: ${action}`).toBeGreaterThanOrEqual(0)
-      const buttonStart = source.lastIndexOf('<button', idx)
-      const buttonEnd = source.indexOf('</button>', idx)
-      const buttonChunk = source.slice(buttonStart, buttonEnd + 9)
-      expect(buttonChunk).toMatch(/min-h-\[48px\]/)
+      const className = getButtonClassName(action)
+      expect(className).toMatch(/min-h-\[48px\]/)
     }
   })
 })

--- a/__tests__/components/mobile-touch-targets.test.ts
+++ b/__tests__/components/mobile-touch-targets.test.ts
@@ -9,16 +9,70 @@ const source = readFileSync(
   'utf8',
 )
 
-describe('mobile fixed controls touch targets', () => {
-  it('keeps the raised 44px hit-area classes', () => {
-    const hits = source.match(/min-(?:w|h)-\[44px\]|min-h-\[48px\]|min-w-\[50px\]/g) ?? []
-    // ドック5ボタン＋カプセル3＋シートClose＋シェア5 の最低ライン
-    expect(hits.length).toBeGreaterThanOrEqual(12)
+describe('mobile fixed controls touch targets (scoped)', () => {
+  it('ensures all 5 main bottom dock navigation buttons meet 48px target', () => {
+    const dockButtons = [
+      "openModal('album')",
+      "openModal('message')",
+      "openModal('bulletin')",
+      "openModal('chat')",
+      "setShowMenuSheet(!showMenuSheet)",
+    ]
+
+    for (const action of dockButtons) {
+      const idx = source.indexOf(action)
+      expect(idx, `Missing dock action: ${action}`).toBeGreaterThanOrEqual(0)
+      const buttonStart = source.lastIndexOf('<button', idx)
+      const buttonEnd = source.indexOf('</button>', idx)
+      const buttonChunk = source.slice(buttonStart, buttonEnd + 9)
+      expect(buttonChunk).toMatch(/min-h-\[48px\]/)
+      expect(buttonChunk).toMatch(/min-w-\[50px\]/)
+    }
   })
 
-  it('ensures fixed navigation controls have sufficient touch target sizing', () => {
-    // 固定ドックおよびコントロールボタンに min-h-[44px] または min-h-[48px] が設定されていることを検証
-    const touchTargetClasses = source.match(/min-h-\[(?:44|48)px\]/g) ?? []
-    expect(touchTargetClasses.length).toBeGreaterThanOrEqual(8)
+  it('ensures music capsule player controls meet >=44px target', () => {
+    const musicControls = [
+      "aria-label={t('selectMusic')}",
+      "aria-label={t('previousTrack')}",
+      "aria-label={isPlaying ? t('pause') : t('play')}",
+      "aria-label={t('nextTrack')}",
+    ]
+
+    for (const label of musicControls) {
+      const idx = source.indexOf(label)
+      expect(idx, `Missing player control: ${label}`).toBeGreaterThanOrEqual(0)
+      const buttonStart = source.lastIndexOf('<button', idx)
+      const buttonEnd = source.indexOf('</button>', idx)
+      const buttonChunk = source.slice(buttonStart, buttonEnd + 9)
+      expect(buttonChunk).toMatch(/min-h-\[44px\]/)
+    }
+  })
+
+  it('ensures sheet close and modal trigger buttons meet >=44px / >=48px target', () => {
+    const sheetCloseIdx = source.indexOf("aria-label={t('close')}")
+    expect(sheetCloseIdx).toBeGreaterThanOrEqual(0)
+    const closeStart = source.lastIndexOf('<button', sheetCloseIdx)
+    const closeEnd = source.indexOf('</button>', sheetCloseIdx)
+    const closeChunk = source.slice(closeStart, closeEnd + 9)
+    expect(closeChunk).toMatch(/min-h-\[44px\]/)
+    expect(closeChunk).toMatch(/min-w-\[44px\]/)
+
+    const sheetActions = [
+      "openModal('omikuji')",
+      "openModal('flashback')",
+      "openModal('quiz')",
+      "openModal('memoryGame')",
+      "openModal('puzzleGame')",
+      "openModal('calendar')",
+    ]
+
+    for (const action of sheetActions) {
+      const idx = source.indexOf(action)
+      expect(idx, `Missing sheet action: ${action}`).toBeGreaterThanOrEqual(0)
+      const buttonStart = source.lastIndexOf('<button', idx)
+      const buttonEnd = source.indexOf('</button>', idx)
+      const buttonChunk = source.slice(buttonStart, buttonEnd + 9)
+      expect(buttonChunk).toMatch(/min-h-\[48px\]/)
+    }
   })
 })

--- a/__tests__/components/mobile-touch-targets.test.ts
+++ b/__tests__/components/mobile-touch-targets.test.ts
@@ -40,16 +40,19 @@ describe('mobile fixed controls touch targets (scoped)', () => {
   })
 
   it('ensures music capsule player controls meet >=44px target in className', () => {
-    const musicControls = [
-      "aria-label={t('selectMusic')}",
-      "aria-label={t('previousTrack')}",
-      "aria-label={isPlaying ? t('pause') : t('play')}",
-      "aria-label={t('nextTrack')}",
+    const selectMusicClass = getButtonClassName('setShowMusicList(!showMusicList)')
+    expect(selectMusicClass).toMatch(/min-h-\[44px\]/)
+
+    const transportControls = [
+      'onClick={prevTrack}',
+      'onClick={toggle}',
+      'onClick={nextTrack}',
     ]
 
-    for (const label of musicControls) {
-      const className = getButtonClassName(label)
+    for (const control of transportControls) {
+      const className = getButtonClassName(control)
       expect(className).toMatch(/min-h-\[44px\]/)
+      expect(className).toMatch(/min-w-\[44px\]/)
     }
   })
 

--- a/__tests__/components/mobile-touch-targets.test.ts
+++ b/__tests__/components/mobile-touch-targets.test.ts
@@ -10,16 +10,52 @@ const source = readFileSync(
 )
 
 function getButtonClassName(identifier: string): string {
-  const idx = source.indexOf(identifier)
-  expect(idx, `Missing identifier: ${identifier}`).toBeGreaterThanOrEqual(0)
-  const tagStart = source.lastIndexOf('<button', idx)
-  const tagEnd = source.indexOf('>', idx)
-  expect(tagStart, `Cannot find <button start for: ${identifier}`).toBeGreaterThanOrEqual(0)
-  expect(tagEnd, `Cannot find > end for: ${identifier}`).toBeGreaterThanOrEqual(0)
-  const openingTag = source.slice(tagStart, tagEnd + 1)
-  const classMatch = openingTag.match(/className=(?:\{`([^`]+)`\}|"([^"]+)")/)
-  expect(classMatch, `Missing className attribute in <button> tag for: ${identifier}`).toBeTruthy()
-  return classMatch![1] || classMatch![2] || ''
+  const buttons: Array<{ tag: string; className: string }> = []
+  let pos = 0
+  while (true) {
+    const startIdx = source.indexOf('<button', pos)
+    if (startIdx === -1) break
+
+    let endIdx = -1
+    let braceDepth = 0
+    let inQuote: string | null = null
+
+    for (let i = startIdx + 7; i < source.length; i++) {
+      const char = source[i]
+      if (inQuote) {
+        if (char === inQuote && source[i - 1] !== '\\') {
+          inQuote = null
+        }
+      } else {
+        if (char === '"' || char === "'" || char === '`') {
+          inQuote = char
+        } else if (char === '{') {
+          braceDepth++
+        } else if (char === '}') {
+          braceDepth = Math.max(0, braceDepth - 1)
+        } else if (char === '>' && braceDepth === 0) {
+          endIdx = i
+          break
+        }
+      }
+    }
+
+    if (endIdx !== -1) {
+      const tag = source.slice(startIdx, endIdx + 1)
+      const classMatch = tag.match(/className=(?:\{`([^`]+)`\}|"([^"]+)")/)
+      buttons.push({
+        tag,
+        className: classMatch ? classMatch[1] || classMatch[2] || '' : '',
+      })
+      pos = endIdx + 1
+    } else {
+      pos = startIdx + 7
+    }
+  }
+
+  const found = buttons.find((btn) => btn.tag.includes(identifier))
+  expect(found, `Cannot find <button> opening tag containing identifier: ${identifier}`).toBeTruthy()
+  return found!.className
 }
 
 describe('mobile fixed controls touch targets (scoped)', () => {

--- a/__tests__/integration/anonymous-flow.local.test.ts
+++ b/__tests__/integration/anonymous-flow.local.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// 匿名フローを API ハンドラレベルで再現するローカル統合テスト。
+// Supabase をメモリ内モックに置き換え、本番データ・本番環境には一切触れない。
+
+type MessageRow = {
+  id: number
+  sender: string
+  message: string
+  birthday_person: string | null
+  media_object_path: string | null
+  created_at: string
+}
+
+let rows: MessageRow[]
+let nextId: number
+
+function makeBuilder() {
+  const builder: Record<string, unknown> = {
+    from: () => builder,
+    select: () => builder,
+    insert: (payload: Partial<MessageRow> | Partial<MessageRow>[]) => {
+      const list = Array.isArray(payload) ? payload : [payload]
+      for (const partial of list) {
+        rows.push({
+          id: nextId++,
+          created_at: new Date().toISOString(),
+          birthday_person: null,
+          media_object_path: null,
+          ...partial,
+        } as MessageRow)
+      }
+      return builder
+    },
+    single: () => Promise.resolve({ data: rows[rows.length - 1] ?? null, error: null }),
+    order: () => builder,
+    limit: () => builder,
+    range: () => builder,
+    eq: () => builder,
+    then: (onFulfilled: (r: { data: MessageRow[]; error: null }) => void) =>
+      onFulfilled({ data: [...rows].sort((a, b) => b.created_at.localeCompare(a.created_at)), error: null }),
+  }
+  return builder
+}
+
+vi.mock('@/lib/supabase/client', () => ({
+  getSupabase: () => makeBuilder(),
+}))
+
+import { GET as getMessages, POST as postMessage } from '@/app/api/messages/route'
+
+describe('anonymous community flow (local, mocked)', () => {
+  beforeEach(() => {
+    rows = []
+    nextId = 1
+  })
+
+  it('anonymous POST is reflected in the anonymous GET list', async () => {
+    const postRes = await postMessage(
+      new NextRequest('http://localhost/api/messages', {
+        method: 'POST',
+        body: JSON.stringify({ sender: '匿名さん', message: 'おめでとう！' }),
+      }),
+    )
+    expect(postRes.status).toBe(201)
+
+    const getRes = await getMessages(new NextRequest('http://localhost/api/messages'))
+    expect(getRes.status).toBe(200)
+    const body = await getRes.json()
+    expect(body.data).toHaveLength(1)
+    expect(body.data[0].message).toBe('おめでとう！')
+  })
+
+  it('rejects invalid sender/message without persisting', async () => {
+    const res = await postMessage(
+      new NextRequest('http://localhost/api/messages', {
+        method: 'POST',
+        body: JSON.stringify({ sender: '', message: '' }),
+      }),
+    )
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(typeof body.error).toBe('string')
+    expect(rows).toHaveLength(0)
+  })
+
+  it('upload route stays a non-mutating stub', async () => {
+    const { POST } = await import('@/app/api/upload/route')
+    const stub = await POST()
+    expect(stub.status).toBe(405)
+  })
+})

--- a/__tests__/integration/anonymous-flow.local.test.ts
+++ b/__tests__/integration/anonymous-flow.local.test.ts
@@ -17,6 +17,9 @@ let rows: MessageRow[]
 let nextId: number
 
 function makeBuilder() {
+  let filteredRows = [...rows]
+  let hasRange = false
+
   const builder: Record<string, unknown> = {
     from: () => builder,
     select: () => builder,
@@ -34,12 +37,31 @@ function makeBuilder() {
       return builder
     },
     single: () => Promise.resolve({ data: rows[rows.length - 1] ?? null, error: null }),
-    order: () => builder,
-    limit: () => builder,
-    range: () => builder,
-    eq: () => builder,
-    then: (onFulfilled: (r: { data: MessageRow[]; error: null }) => void) =>
-      onFulfilled({ data: [...rows].sort((a, b) => b.created_at.localeCompare(a.created_at)), error: null }),
+    order: (column: string, { ascending = true }: { ascending?: boolean } = {}) => {
+      filteredRows.sort((a, b) => {
+        const valA = String(a[column as keyof MessageRow] ?? '')
+        const valB = String(b[column as keyof MessageRow] ?? '')
+        return ascending ? valA.localeCompare(valB) : valB.localeCompare(valA)
+      })
+      return builder
+    },
+    eq: (column: string, value: unknown) => {
+      filteredRows = filteredRows.filter((r) => r[column as keyof MessageRow] === value)
+      return builder
+    },
+    limit: (count: number) => {
+      if (!hasRange) {
+        filteredRows = filteredRows.slice(0, count)
+      }
+      return builder
+    },
+    range: (from: number, to: number) => {
+      hasRange = true
+      filteredRows = filteredRows.slice(from, to + 1)
+      return builder
+    },
+    then: (onFulfilled: (r: { data: MessageRow[]; error: null; count: number }) => void) =>
+      onFulfilled({ data: filteredRows, count: filteredRows.length, error: null }),
   }
   return builder
 }

--- a/__tests__/integration/production-snapshot-regression.test.ts
+++ b/__tests__/integration/production-snapshot-regression.test.ts
@@ -31,7 +31,8 @@ afterEach(() => {
 })
 
 describe('production allowlist integration', () => {
-  it('applies only clean-commit integrationPaths and ignores dirty production files', async () => {
+  // Windows では git サブプロセスが既定 5 秒を超えることがあるため、テスト単位で余裕を持たせる
+  it('applies only clean-commit integrationPaths and ignores dirty production files', { timeout: 30_000 }, async () => {
     const { applyProductionAllowlist } = await loadAllowlistScript()
     const productionRoot = createRepository()
     mkdirSync(join(productionRoot, 'data', 'festivals', 'jp'), { recursive: true })
@@ -66,7 +67,7 @@ describe('production allowlist integration', () => {
     expect(existsSync(join(destination, 'supabase', 'config.toml'))).toBe(false)
   })
 
-  it('rejects excluded paths and forbidden staged files', async () => {
+  it('rejects excluded paths and forbidden staged files', { timeout: 30_000 }, async () => {
     const { checkStagedFiles, readIntegrationPaths } = await loadAllowlistScript()
     expect(() => readIntegrationPaths({
       allowedPathScopes: ['data/'],

--- a/__tests__/lib/festivals/parity.test.ts
+++ b/__tests__/lib/festivals/parity.test.ts
@@ -194,4 +194,27 @@ describe('compareCatalogs', () => {
     expect(report.duplicateIds).toEqual([{ id: 'identity-duplicate' }])
     expect(report.shared).toEqual([])
   })
+
+  it('rejects non-object snapshot entries instead of dropping them', () => {
+    expect(() => compareCatalogs({ events: [null] }, { events: [pack()] })).toThrow(/malformed festival pack/)
+    expect(() => compareCatalogs({ events: [pack()] }, { events: ['broken'] })).toThrow(/malformed festival pack/)
+  })
+
+  it('does not mask runtime contract drift behind matching identity', () => {
+    const report = compareCatalogs(
+      [
+        pack({ id: 'precedence-drift', locale: 'en', enabled: true, status: 'enabled', priority: 10 }),
+        pack({ id: 'precedence-drift', locale: 'ja', enabled: true, status: 'enabled', priority: 10 }),
+      ],
+      [
+        pack({ id: 'precedence-drift', locale: 'en', enabled: false, status: 'disabled', priority: 20 }),
+        pack({ id: 'precedence-drift', locale: 'ja', enabled: false, status: 'disabled', priority: 20 }),
+      ],
+    )
+
+    expect(report.shared).toEqual([])
+    expect(report.sameDateDifferentContent).toEqual([])
+    expect(report.duplicateIds).toEqual([])
+    expect(report.runtimeContractMismatch).toEqual([{ id: 'precedence-drift' }])
+  })
 })

--- a/__tests__/lib/healthcheck.test.ts
+++ b/__tests__/lib/healthcheck.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const OK_RESPONSE = { ok: true, status: 200 } as Response
+
+describe('checkSupabaseReadonly', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('performs a read-only GET with apikey headers and reports reachable', async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co'
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key'
+    vi.resetModules()
+
+    const fetchMock = vi.fn().mockResolvedValue(OK_RESPONSE)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { checkSupabaseReadonly } = await import('@/lib/healthcheck')
+    const result = await checkSupabaseReadonly(1000, fetchMock as unknown as typeof fetch)
+
+    expect(result).toEqual({ ok: true, status: 200, detail: 'reachable' })
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('https://example.supabase.co/rest/v1/')
+    expect(init.method).toBe('GET')
+    expect((init.headers as Record<string, string>).apikey).toBe('anon-key')
+  })
+
+  it('reports timeout when the endpoint does not respond in time', async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co'
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key'
+    vi.resetModules()
+
+    const fetchMock = vi.fn().mockImplementation(
+      (_url: string, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () =>
+            reject(Object.assign(new Error('Aborted'), { name: 'AbortError' })),
+          )
+        }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { checkSupabaseReadonly } = await import('@/lib/healthcheck')
+    const result = await checkSupabaseReadonly(20, fetchMock as unknown as typeof fetch)
+
+    expect(result.ok).toBe(false)
+    expect(result.detail).toBe('timeout')
+  })
+
+  it('reports unhealthy for a non-2xx response without throwing', async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co'
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key'
+    vi.resetModules()
+
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 503 })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { checkSupabaseReadonly } = await import('@/lib/healthcheck')
+    const result = await checkSupabaseReadonly(1000, fetchMock as unknown as typeof fetch)
+
+    expect(result).toEqual({ ok: false, status: 503, detail: 'unhealthy' })
+  })
+})

--- a/__tests__/lib/hooks/useMediaQuery.test.ts
+++ b/__tests__/lib/hooks/useMediaQuery.test.ts
@@ -40,6 +40,7 @@ describe('useMediaQuery', () => {
     expect(result.current).toBe(true)
 
     act(() => {
+      ;(mediaQueryList as unknown as { matches: boolean }).matches = false
       listeners.forEach((cb) => cb({ matches: false } as MediaQueryListEvent))
     })
     expect(result.current).toBe(false)

--- a/__tests__/lib/hooks/useMediaQuery.test.ts
+++ b/__tests__/lib/hooks/useMediaQuery.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import {
   useMediaQuery,
@@ -11,6 +11,10 @@ import {
 describe('useMediaQuery', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('should return false by default', () => {

--- a/__tests__/lib/hooks/useMediaQuery.test.ts
+++ b/__tests__/lib/hooks/useMediaQuery.test.ts
@@ -21,21 +21,28 @@ describe('useMediaQuery', () => {
   it('should update when media query changes', () => {
     const listeners: Array<(e: MediaQueryListEvent) => void> = []
 
-    vi.spyOn(window, 'matchMedia').mockImplementation((query) => ({
-      matches: query.includes('768'),
-      media: query,
+    const mediaQueryList = {
+      matches: true,
+      media: '(min-width: 768px)',
       onchange: null,
       addListener: vi.fn(),
       removeListener: vi.fn(),
-      addEventListener: (_: string, cb: (e: MediaQueryListEvent) => void) => {
-        listeners.push(cb)
-      },
+      addEventListener: vi.fn((_type: string, cb: EventListener) => {
+        listeners.push(cb as (e: MediaQueryListEvent) => void)
+      }),
       removeEventListener: vi.fn(),
       dispatchEvent: vi.fn(),
-    }))
+    } as unknown as MediaQueryList
+
+    vi.spyOn(window, 'matchMedia').mockImplementation(() => mediaQueryList)
 
     const { result } = renderHook(() => useMediaQuery('(min-width: 768px)'))
     expect(result.current).toBe(true)
+
+    act(() => {
+      listeners.forEach((cb) => cb({ matches: false } as MediaQueryListEvent))
+    })
+    expect(result.current).toBe(false)
   })
 })
 

--- a/__tests__/lib/hooks/useMediaQuery.test.ts
+++ b/__tests__/lib/hooks/useMediaQuery.test.ts
@@ -73,4 +73,22 @@ describe('usePrefersReducedMotion', () => {
     const { result } = renderHook(() => usePrefersReducedMotion())
     expect(typeof result.current).toBe('boolean')
   })
+
+  it('should reflect prefers-reduced-motion from matchMedia', () => {
+    vi.spyOn(window, 'matchMedia').mockImplementation((query: string) =>
+      ({
+        matches: query.includes('prefers-reduced-motion'),
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }) as unknown as MediaQueryList,
+    )
+
+    const { result } = renderHook(() => usePrefersReducedMotion())
+    expect(result.current).toBe(true)
+  })
 })

--- a/__tests__/lib/hooks/useUserName.test.ts
+++ b/__tests__/lib/hooks/useUserName.test.ts
@@ -56,4 +56,43 @@ describe('useUserName', () => {
 
     expect(result.current.userName).toBe('別タブ次郎')
   })
+
+  it('preserves user input in memory when localStorage.setItem throws', () => {
+    const originalSetItem = localStorage.setItem
+    localStorage.setItem = () => {
+      throw new Error('QuotaExceededError')
+    }
+
+    try {
+      const { result } = renderHook(() => useUserName())
+      act(() => {
+        result.current.setUserName('フォールバック太郎')
+      })
+
+      expect(result.current.userName).toBe('フォールバック太郎')
+      expect(result.current.hasUserName).toBe(true)
+    } finally {
+      localStorage.setItem = originalSetItem
+    }
+  })
+
+  it('safely clears memory state when localStorage.removeItem throws', () => {
+    localStorage.setItem('birthday_user_name', '花子')
+    const originalRemoveItem = localStorage.removeItem
+    localStorage.removeItem = () => {
+      throw new Error('SecurityError')
+    }
+
+    try {
+      const { result } = renderHook(() => useUserName())
+      act(() => {
+        result.current.clearUserName()
+      })
+
+      expect(result.current.userName).toBe('')
+      expect(result.current.hasUserName).toBe(false)
+    } finally {
+      localStorage.removeItem = originalRemoveItem
+    }
+  })
 })

--- a/__tests__/lib/hooks/useUserName.test.ts
+++ b/__tests__/lib/hooks/useUserName.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useUserName } from '@/lib/hooks/useUserName'
+
+describe('useUserName', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('initializes with stored value and isLoaded is true on client', () => {
+    localStorage.setItem('birthday_user_name', '花子')
+    const { result } = renderHook(() => useUserName())
+
+    expect(result.current.userName).toBe('花子')
+    expect(result.current.hasUserName).toBe(true)
+    expect(result.current.isLoaded).toBe(true)
+  })
+
+  it('updates userName and persists to localStorage via setUserName', () => {
+    const { result } = renderHook(() => useUserName())
+
+    act(() => {
+      result.current.setUserName('太郎')
+    })
+
+    expect(result.current.userName).toBe('太郎')
+    expect(result.current.hasUserName).toBe(true)
+    expect(localStorage.getItem('birthday_user_name')).toBe('太郎')
+  })
+
+  it('clears userName and localStorage via clearUserName', () => {
+    localStorage.setItem('birthday_user_name', '花子')
+    const { result } = renderHook(() => useUserName())
+
+    act(() => {
+      result.current.clearUserName()
+    })
+
+    expect(result.current.userName).toBe('')
+    expect(result.current.hasUserName).toBe(false)
+    expect(localStorage.getItem('birthday_user_name')).toBeNull()
+  })
+})

--- a/__tests__/lib/hooks/useUserName.test.ts
+++ b/__tests__/lib/hooks/useUserName.test.ts
@@ -40,4 +40,20 @@ describe('useUserName', () => {
     expect(result.current.hasUserName).toBe(false)
     expect(localStorage.getItem('birthday_user_name')).toBeNull()
   })
+
+  it('updates userName on subsequent storage event even after setUserName in same tab', () => {
+    const { result } = renderHook(() => useUserName())
+
+    act(() => {
+      result.current.setUserName('ローカル太郎')
+    })
+    expect(result.current.userName).toBe('ローカル太郎')
+
+    act(() => {
+      localStorage.setItem('birthday_user_name', '別タブ次郎')
+      window.dispatchEvent(new StorageEvent('storage', { key: 'birthday_user_name', newValue: '別タブ次郎' }))
+    })
+
+    expect(result.current.userName).toBe('別タブ次郎')
+  })
 })

--- a/__tests__/lib/i18n/translation-parity.test.ts
+++ b/__tests__/lib/i18n/translation-parity.test.ts
@@ -100,7 +100,7 @@ describe('translation parity', () => {
     ] as const
     for (const key of convertedKeys) {
       for (const pack of localePacks) {
-        expect(pack.translations[key], `${pack.locale}:${key}`).toBeTruthy()
+        expect(pack.translations[key]).toBeTruthy()
         expect(pack.translations[key]).not.toBe(key)
       }
       expect(translate('fr-FR', key, 'ja')).toBe(localePacks.find((p) => p.locale === 'ja')?.translations[key])
@@ -112,10 +112,9 @@ describe('translation parity', () => {
       [...value.matchAll(/\{(\w+)\}/g)].map((match) => match[1]).sort()
     const [enPack, jaPack] = localePacks
     for (const key of translationKeys) {
-      expect(extract(enPack.translations[key]), `${key} (en)`).toEqual(
-        extract(jaPack.translations[key]),
-        `${key} (ja)`,
-      )
+      const enPlaceholders = extract(enPack.translations[key])
+      const jaPlaceholders = extract(jaPack.translations[key])
+      expect(enPlaceholders).toEqual(jaPlaceholders)
     }
   })
 })

--- a/__tests__/lib/stores/uiStore-focus.test.ts
+++ b/__tests__/lib/stores/uiStore-focus.test.ts
@@ -54,4 +54,21 @@ describe('uiStore modal focus lifecycle', () => {
     await new Promise((resolve) => requestAnimationFrame(resolve))
     expect(document.activeElement).toBe(document.body)
   })
+
+  it('falls back to persistent navigation button when original trigger is unmounted', async () => {
+    const nav = document.createElement('nav')
+    const navButton = document.createElement('button')
+    nav.appendChild(navButton)
+    const trigger = document.createElement('button')
+    document.body.append(nav, trigger)
+    trigger.focus()
+
+    act(() => useUIStore.getState().openModal('album'))
+    trigger.remove()
+
+    act(() => useUIStore.getState().closeModal())
+    await new Promise((resolve) => requestAnimationFrame(resolve))
+
+    expect(document.activeElement).toBe(navButton)
+  })
 })

--- a/__tests__/lib/stores/uiStore-focus.test.ts
+++ b/__tests__/lib/stores/uiStore-focus.test.ts
@@ -71,4 +71,48 @@ describe('uiStore modal focus lifecycle', () => {
 
     expect(document.activeElement).toBe(navButton)
   })
+
+  it('preserves initial page trigger when transitioning directly between modals', async () => {
+    const pageTrigger = document.createElement('button')
+    document.body.appendChild(pageTrigger)
+    pageTrigger.focus()
+
+    act(() => useUIStore.getState().openModal('album'))
+
+    // モーダルA内部のボタンにフォーカスがある状態でモーダルBへ直接遷移
+    const modalInnerButton = document.createElement('button')
+    document.body.appendChild(modalInnerButton)
+    modalInnerButton.focus()
+
+    act(() => useUIStore.getState().openModal('message'))
+
+    // モーダルBを閉じた際、モーダル内部ボタンではなく最初のページトリガーへ復元されること
+    modalInnerButton.remove()
+    act(() => useUIStore.getState().closeModal())
+    await new Promise((resolve) => requestAnimationFrame(resolve))
+
+    expect(document.activeElement).toBe(pageTrigger)
+  })
+
+  it('skips disabled or hidden fallback buttons', async () => {
+    const nav = document.createElement('nav')
+    const disabledButton = document.createElement('button')
+    disabledButton.setAttribute('disabled', 'true')
+    const hiddenButton = document.createElement('button')
+    hiddenButton.style.display = 'none'
+    const visibleButton = document.createElement('button')
+    nav.append(disabledButton, hiddenButton, visibleButton)
+
+    const trigger = document.createElement('button')
+    document.body.append(nav, trigger)
+    trigger.focus()
+
+    act(() => useUIStore.getState().openModal('album'))
+    trigger.remove()
+
+    act(() => useUIStore.getState().closeModal())
+    await new Promise((resolve) => requestAnimationFrame(resolve))
+
+    expect(document.activeElement).toBe(visibleButton)
+  })
 })

--- a/__tests__/lib/stores/uiStore-focus.test.ts
+++ b/__tests__/lib/stores/uiStore-focus.test.ts
@@ -1,0 +1,57 @@
+import { act } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { useUIStore } from '@/lib/stores/uiStore'
+
+describe('uiStore modal focus lifecycle', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    act(() => useUIStore.setState({ activeModal: null }))
+  })
+
+  it('restores focus to the trigger after closeModal when focus fell back to body', async () => {
+    const trigger = document.createElement('button')
+    document.body.appendChild(trigger)
+    trigger.focus()
+    expect(document.activeElement).toBe(trigger)
+
+    act(() => useUIStore.getState().openModal('album'))
+    expect(useUIStore.getState().activeModal).toBe('album')
+
+    // Modal unmount 後にフォーカスが body へ落ちたケースを再現
+    trigger.blur()
+    expect(document.activeElement).toBe(document.body)
+
+    act(() => useUIStore.getState().closeModal())
+    await new Promise((resolve) => requestAnimationFrame(resolve))
+
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('does not steal focus when another element already took it', async () => {
+    const trigger = document.createElement('button')
+    const other = document.createElement('input')
+    document.body.append(trigger, other)
+    trigger.focus()
+
+    act(() => useUIStore.getState().openModal('album'))
+    other.focus()
+
+    act(() => useUIStore.getState().closeModal())
+    await new Promise((resolve) => requestAnimationFrame(resolve))
+
+    expect(document.activeElement).toBe(other)
+  })
+
+  it('does not throw when the trigger was removed from the DOM', async () => {
+    const trigger = document.createElement('button')
+    document.body.appendChild(trigger)
+    trigger.focus()
+
+    act(() => useUIStore.getState().openModal('album'))
+    trigger.remove()
+
+    expect(() => act(() => useUIStore.getState().closeModal())).not.toThrow()
+    await new Promise((resolve) => requestAnimationFrame(resolve))
+    expect(document.activeElement).toBe(document.body)
+  })
+})

--- a/__tests__/lib/upload-validation.test.ts
+++ b/__tests__/lib/upload-validation.test.ts
@@ -22,4 +22,32 @@ describe('validateCommunityMediaFile', () => {
     expect(getMediaKind('video/webm')).toBe('video')
     expect(getMediaKind('audio/webm')).toBe('audio')
   })
+
+  it('rejects files over the 50MB limit', () => {
+    const oversized = new File([new Uint8Array(51)], 'big.png', { type: 'image/png' })
+    Object.defineProperty(oversized, 'size', { value: 50 * 1024 * 1024 + 1 })
+
+    expect(validateCommunityMediaFile(oversized)).toEqual({
+      valid: false,
+      error: 'ファイルサイズは50MB以下にしてください',
+    })
+  })
+
+  it('rejects zero-byte files', () => {
+    const empty = new File([], 'empty.png', { type: 'image/png' })
+
+    expect(validateCommunityMediaFile(empty)).toEqual({
+      valid: false,
+      error: 'ファイルサイズは50MB以下にしてください',
+    })
+  })
+
+  it('rejects unsupported subtypes even when the prefix matches', () => {
+    const heic = new File(['image'], 'photo.heic', { type: 'image/heic' })
+
+    expect(validateCommunityMediaFile(heic)).toEqual({
+      valid: false,
+      error: 'サポートされていないファイル形式です',
+    })
+  })
 })

--- a/__tests__/scripts/collect-festival-snapshot.test.ts
+++ b/__tests__/scripts/collect-festival-snapshot.test.ts
@@ -192,6 +192,7 @@ describe('collectSnapshot', () => {
     execFileSync(process.execPath, args)
 
     const allowlist = JSON.parse(readFileSync(allowlistOutput, 'utf8'))
+    const openSource = JSON.parse(readFileSync(openSourceOutput, 'utf8'))
     expect(JSON.parse(readFileSync(productionOutput, 'utf8'))).not.toHaveProperty('stale')
     expect(allowlist.allowedPathScopes).toEqual(['data/festivals/', 'data/i18n/'])
     expect(allowlist.integrationPaths).toEqual(['data/festivals/jp/ja.json', 'data/i18n/ja.json'])
@@ -199,7 +200,8 @@ describe('collectSnapshot', () => {
     expect(allowlist.allowedPaths).not.toContain('data/festivals/jp/notes.txt')
     expect(allowlist.excludedPaths.dirty).not.toContain('data/festivals/jp/ja.json')
     expect(allowlist.excludedPaths.supabase).toContain('supabase/migrations/20260812163000_reset_and_create_anonymous_community.sql')
-    expect(allowlist.integrationPaths).not.toContain('supabase/migrations/20260812163000_reset_and_create_anonymous_community.sql')
+    expect(openSource.files.excluded).toContain('supabase/migrations/20260812163000_reset_and_create_anonymous_community.sql')
+    expect(openSource.files.reasons['supabase/migrations/20260812163000_reset_and_create_anonymous_community.sql']).toBe('Supabase 設定とスキーマ')
 
     writeFileSync(productionOutput, '{"keep":true}\n')
     const failingArgs = withOption(args, '--production-commit', 'missing-commit')

--- a/__tests__/scripts/collect-festival-snapshot.test.ts
+++ b/__tests__/scripts/collect-festival-snapshot.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'nod
 import { pathToFileURL } from 'node:url'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, describe, expect, it } from 'vitest'
 
 const temporaryDirectories: string[] = []
 
@@ -36,11 +36,21 @@ function writeTrackedFixture(root: string): void {
   writeFileSync(join(root, 'data', 'i18n', 'ja.json'), JSON.stringify({ locale: 'ja', translations: { title: '誕生日' } }))
 }
 
-afterEach(() => {
+function removeTemporaryDirectories(): void {
+  const failures: Error[] = []
   for (const directory of temporaryDirectories.splice(0)) {
-    rmSync(directory, { recursive: true, force: true })
+    try {
+      rmSync(directory, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 })
+    } catch (error) {
+      failures.push(error instanceof Error ? error : new Error(String(error)))
+    }
   }
-})
+  if (failures.length > 0) throw failures[0]
+}
+
+afterEach(removeTemporaryDirectories)
+
+afterAll(removeTemporaryDirectories)
 
 describe('collectSnapshot', () => {
   const withOption = (args: string[], flag: string, value: string): string[] => {
@@ -51,7 +61,7 @@ describe('collectSnapshot', () => {
     return next
   }
 
-  it('records clean commit metadata and excludes dirty or sensitive paths', async () => {
+  it('records clean commit metadata and excludes dirty or sensitive paths', { timeout: 30_000 }, async () => {
     const productionRoot = createRepository()
     writeTrackedFixture(productionRoot)
     execFileSync('git', ['-C', productionRoot, 'add', '.'])
@@ -120,7 +130,7 @@ describe('collectSnapshot', () => {
     })).toThrow(/legacy FESTIVAL_DATES.*validated festival packs/)
   })
 
-  it('records both paths for a dirty rename without truncating the old path', async () => {
+  it('records both paths for a dirty rename without truncating the old path', { timeout: 30_000 }, async () => {
     const productionRoot = createRepository()
     writeTrackedFixture(productionRoot)
     execFileSync('git', ['-C', productionRoot, 'add', '.'])
@@ -146,7 +156,7 @@ describe('collectSnapshot', () => {
     expect(snapshot.openSource.files.reasons['.env.local']).toBe('環境変数と秘密情報')
   })
 
-  it('regenerates existing outputs and preserves existing files when collection stops before writing', () => {
+  it('regenerates existing outputs and preserves existing files when collection stops before writing', { timeout: 30_000 }, () => {
     const productionRoot = createRepository()
     writeTrackedFixture(productionRoot)
     execFileSync('git', ['-C', productionRoot, 'add', '.'])
@@ -155,6 +165,11 @@ describe('collectSnapshot', () => {
     const openSourceRoot = createRepository()
     writeTrackedFixture(openSourceRoot)
     writeFileSync(join(openSourceRoot, 'data', 'i18n', 'en.json'), JSON.stringify({ locale: 'en', translations: { title: 'Birthday' } }))
+    mkdirSync(join(openSourceRoot, 'supabase', 'migrations'), { recursive: true })
+    writeFileSync(
+      join(openSourceRoot, 'supabase', 'migrations', '20260812163000_reset_and_create_anonymous_community.sql'),
+      'alter table public.bulletin_posts enable row level security;\n',
+    )
     execFileSync('git', ['-C', openSourceRoot, 'add', '.'])
     execFileSync('git', ['-C', openSourceRoot, 'commit', '--quiet', '-m', 'snapshot'])
 
@@ -185,6 +200,8 @@ describe('collectSnapshot', () => {
     expect(allowlist.allowedPaths).toEqual(['data/festivals/jp/ja.json', 'data/i18n/ja.json'])
     expect(allowlist.allowedPaths).not.toContain('data/festivals/jp/notes.txt')
     expect(allowlist.excludedPaths.dirty).not.toContain('data/festivals/jp/ja.json')
+    expect(allowlist.excludedPaths.supabase).toContain('supabase/migrations/20260812163000_reset_and_create_anonymous_community.sql')
+    expect(allowlist.integrationPaths).not.toContain('supabase/migrations/20260812163000_reset_and_create_anonymous_community.sql')
 
     writeFileSync(productionOutput, '{"keep":true}\n')
     const failingArgs = withOption(args, '--production-commit', 'missing-commit')

--- a/__tests__/scripts/collect-festival-snapshot.test.ts
+++ b/__tests__/scripts/collect-festival-snapshot.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'nod
 import { pathToFileURL } from 'node:url'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterAll, afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 
 const temporaryDirectories: string[] = []
 
@@ -49,8 +49,6 @@ function removeTemporaryDirectories(): void {
 }
 
 afterEach(removeTemporaryDirectories)
-
-afterAll(removeTemporaryDirectories)
 
 describe('collectSnapshot', () => {
   const withOption = (args: string[], flag: string, value: string): string[] => {

--- a/__tests__/scripts/generate-data-manifest.test.ts
+++ b/__tests__/scripts/generate-data-manifest.test.ts
@@ -2,7 +2,7 @@ import { execFileSync } from 'node:child_process'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, describe, expect, it } from 'vitest'
 
 const scriptPath = join(process.cwd(), 'scripts', 'generate-data-manifest.mjs')
 const temporaryDirectories: string[] = []
@@ -55,11 +55,21 @@ function runGenerator(root: string, ...args: string[]): string {
   })
 }
 
-afterEach(() => {
+function removeTemporaryDirectories(): void {
+  const failures: Error[] = []
   for (const directory of temporaryDirectories.splice(0)) {
-    rmSync(directory, { recursive: true, force: true })
+    try {
+      rmSync(directory, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 })
+    } catch (error) {
+      failures.push(error instanceof Error ? error : new Error(String(error)))
+    }
   }
-})
+  if (failures.length > 0) throw failures[0]
+}
+
+afterEach(removeTemporaryDirectories)
+
+afterAll(removeTemporaryDirectories)
 
 describe('generate-data-manifest', () => {
   it('discovers packs and writes deterministic generated manifests', () => {
@@ -254,5 +264,35 @@ describe('generate-data-manifest', () => {
 
     expect(() => runGenerator(root, '--write')).toThrow(/festival-pack.schema.json/)
     expect(existsSync(join(root, 'data', 'generated', 'festival-packs.ts'))).toBe(false)
+  })
+
+  it('passes --check on a minimal valid fixture after generating manifests', () => {
+    const root = createFixture()
+    writePack(root, 'ja.json', 'check-event', 'hanami', 'ja')
+    writePack(root, 'en.json', 'check-event', 'hanami', 'en')
+
+    runGenerator(root, '--write')
+    expect(runGenerator(root, '--check')).toBe('')
+  })
+
+  it('fails --check when the ja festival pack is deleted', () => {
+    const root = createFixture()
+    writePack(root, 'ja.json', 'locale-gap-event', 'hanami', 'ja')
+    writePack(root, 'en.json', 'locale-gap-event', 'hanami', 'en')
+    rmSync(join(root, 'data', 'festivals', 'jp', 'ja.json'))
+
+    expect(() => runGenerator(root, '--check')).toThrow(/locale が不足しています: locale-gap-event:ja/)
+  })
+
+  it('fails --check when i18n schema drops the translations requirement', () => {
+    const root = createFixture()
+    writePack(root, 'ja.json', 'schema-drift-event', 'hanami', 'ja')
+    writePack(root, 'en.json', 'schema-drift-event', 'hanami', 'en')
+    writeFileSync(
+      join(root, 'data', 'schemas', 'i18n.schema.json'),
+      JSON.stringify({ type: 'object', required: ['locale'] }),
+    )
+
+    expect(() => runGenerator(root, '--check')).toThrow(/i18n\.schema\.json\.required に translations がありません/)
   })
 })

--- a/app/globals.css
+++ b/app/globals.css
@@ -1427,3 +1427,15 @@ body.theme-bunka {
     padding: 6px 8px;
   }
 }
+
+/* ===== prefers-reduced-motion: CSS アニメーション/トランジションを全体で抑制 ===== */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ import { LANGUAGE_COOKIE_NAME } from '@/lib/i18n/cookie'
 import { DEFAULT_LOCALE, resolveLocale } from '@/lib/i18n/resolveLocale'
 import { ThemeProvider } from '@/lib/providers/ThemeProvider'
 import { QueryProvider } from '@/lib/providers/QueryProvider'
+import { MotionConfig } from 'framer-motion'
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://happy-birthday.vercel.app'),
@@ -81,7 +82,10 @@ export default async function RootLayout({
         <QueryProvider>
           <ThemeProvider>
             <LanguageProvider initialLocale={locale}>
-              {children}
+              {/* prefers-reduced-motion を framer-motion 全体で尊重 */}
+              <MotionConfig reducedMotion="user">
+                {children}
+              </MotionConfig>
             </LanguageProvider>
           </ThemeProvider>
         </QueryProvider>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { BirthdayChecker } from '@/components/features/BirthdayChecker'
 import { MainLayout } from '@/components/layout/MainLayout'
 import { ThemeEffects } from '@/components/effects/ThemeEffects'
@@ -9,17 +9,10 @@ import { useThemeContext } from '@/lib/providers/ThemeProvider'
 
 export default function Home() {
   const { themeConfig, currentTheme } = useThemeContext()
-  const [isMounted, setIsMounted] = useState(false)
 
   useEffect(() => {
-    setIsMounted(true)
-  }, [])
-
-  useEffect(() => {
-    if (isMounted) {
-      document.body.className = `theme-${currentTheme}`
-    }
-  }, [currentTheme, isMounted])
+    document.body.className = `theme-${currentTheme}`
+  }, [currentTheme])
 
   return (
     <div

--- a/components/community/CameraCapture.tsx
+++ b/components/community/CameraCapture.tsx
@@ -236,15 +236,6 @@ function getSupportedVideoMimeType(): string | undefined {
     }
   }, [])
 
-  // フォーカス位置に依存しないよう、document レベルでも Escape を処理する
-  useEffect(() => {
-    const handleDocumentEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') handleClose()
-    }
-    document.addEventListener('keydown', handleDocumentEscape)
-    return () => document.removeEventListener('keydown', handleDocumentEscape)
-  }, [handleClose])
-
   // Tab キーによるダイアログ内のフォーカストラップ
   useEffect(() => {
     const handleTab = (e: KeyboardEvent) => {
@@ -256,7 +247,7 @@ function getSupportedVideoMimeType(): string | undefined {
       const firstElement = focusableElements[0] as HTMLElement
       const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement
 
-      if (e.shiftKey && document.activeElement === firstElement) {
+      if (e.shiftKey && (document.activeElement === firstElement || document.activeElement === containerRef.current)) {
         e.preventDefault()
         lastElement?.focus()
       } else if (!e.shiftKey && document.activeElement === lastElement) {

--- a/components/community/CameraCapture.tsx
+++ b/components/community/CameraCapture.tsx
@@ -245,6 +245,30 @@ function getSupportedVideoMimeType(): string | undefined {
     return () => document.removeEventListener('keydown', handleDocumentEscape)
   }, [handleClose])
 
+  // Tab キーによるダイアログ内のフォーカストラップ
+  useEffect(() => {
+    const handleTab = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab' || !containerRef.current) return
+      const focusableElements = containerRef.current.querySelectorAll(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      )
+      if (focusableElements.length === 0) return
+      const firstElement = focusableElements[0] as HTMLElement
+      const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement
+
+      if (e.shiftKey && document.activeElement === firstElement) {
+        e.preventDefault()
+        lastElement?.focus()
+      } else if (!e.shiftKey && document.activeElement === lastElement) {
+        e.preventDefault()
+        firstElement?.focus()
+      }
+    }
+
+    document.addEventListener('keydown', handleTab)
+    return () => document.removeEventListener('keydown', handleTab)
+  }, [])
+
   const cameraContent = (
     <div
       ref={containerRef}

--- a/components/community/CameraCapture.tsx
+++ b/components/community/CameraCapture.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, useCallback, useEffect } from 'react'
+import { useState, useRef, useCallback, useEffect, useSyncExternalStore } from 'react'
 import { createPortal } from 'react-dom'
 import { Icon } from '@/components/ui/Icon'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
@@ -13,12 +13,11 @@ interface CameraCaptureProps {
 
 export function CameraCapture({ mode, onCapture, onClose }: CameraCaptureProps) {
   const { t } = useLanguage()
-  const [mounted, setMounted] = useState(false)
-  
-  useEffect(() => {
-    setMounted(true)
-    return () => setMounted(false)
-  }, [])
+  const mounted = useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false
+  )
   const videoRef = useRef<HTMLVideoElement>(null)
   const mediaRecorderRef = useRef<MediaRecorder | null>(null)
   const chunksRef = useRef<Blob[]>([])
@@ -223,8 +222,27 @@ function getSupportedVideoMimeType(): string | undefined {
     onClose()
   }, [stopCamera, onClose])
 
+  const containerRef = useRef<HTMLDivElement>(null)
+  const lastFocusedRef = useRef<Element | null>(null)
+
+  // ダイアログとしてのフォーカス lifecycle（開いたら奪い、閉じたら返す）
+  useEffect(() => {
+    lastFocusedRef.current = document.activeElement
+    containerRef.current?.focus()
+    return () => {
+      if (lastFocusedRef.current instanceof HTMLElement) {
+        lastFocusedRef.current.focus()
+      }
+    }
+  }, [])
+
   const cameraContent = (
     <div
+      ref={containerRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label={mode === 'photo' ? t('takePhoto') : t('takeVideo')}
+      tabIndex={-1}
       style={{
         position: 'fixed',
         inset: 0,
@@ -232,9 +250,17 @@ function getSupportedVideoMimeType(): string | undefined {
         zIndex: 100000,
         display: 'flex',
         flexDirection: 'column',
+        outline: 'none',
       }}
       onClick={(e) => e.stopPropagation()}
-      onKeyDown={(e) => e.stopPropagation()}
+      onKeyDown={(e) => {
+        // Escape で閉じつつ、外側のモーダルへ伝播させない
+        if (e.key === 'Escape') {
+          e.preventDefault()
+          handleClose()
+        }
+        e.stopPropagation()
+      }}
     >
       {/* ヘッダー */}
       <div

--- a/components/community/CameraCapture.tsx
+++ b/components/community/CameraCapture.tsx
@@ -236,6 +236,15 @@ function getSupportedVideoMimeType(): string | undefined {
     }
   }, [])
 
+  // フォーカス位置に依存しないよう、document レベルでも Escape を処理する
+  useEffect(() => {
+    const handleDocumentEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') handleClose()
+    }
+    document.addEventListener('keydown', handleDocumentEscape)
+    return () => document.removeEventListener('keydown', handleDocumentEscape)
+  }, [handleClose])
+
   const cameraContent = (
     <div
       ref={containerRef}

--- a/components/community/GiftAnimation.tsx
+++ b/components/community/GiftAnimation.tsx
@@ -10,19 +10,30 @@ interface GiftAnimationProps {
   onComplete?: () => void
 }
 
+// きらめきの表示位置（決定論的：レンダー毎の乱数呼び出しを避けるため固定値）
+const SPARKLE_POSITIONS = [
+  { top: '24%', left: '30%' },
+  { top: '30%', left: '72%' },
+  { top: '38%', left: '22%' },
+  { top: '45%', left: '55%' },
+  { top: '52%', left: '35%' },
+  { top: '60%', left: '76%' },
+  { top: '66%', left: '25%' },
+  { top: '74%', left: '64%' },
+]
+
+// 浮遊パーティクル（決定論的配置：x は均等分散、delay は 0〜0.45 秒）
+const GIFT_PARTICLES = Array.from({ length: 20 }, (_, i) => ({
+  id: i,
+  x: (i * 37) % 100,
+  delay: ((i * 7) % 10) * 0.05,
+}))
+
 export default function GiftAnimation({ emoji, giftName, sender, onComplete }: GiftAnimationProps) {
   const { t } = useLanguage()
   const [isVisible, setIsVisible] = useState(true)
-  const [particles, setParticles] = useState<Array<{ id: number; x: number; delay: number }>>([])
 
   useEffect(() => {
-    const newParticles = Array.from({ length: 20 }, (_, i) => ({
-      id: i,
-      x: Math.random() * 100,
-      delay: Math.random() * 0.5,
-    }))
-    setParticles(newParticles)
-
     // アニメーション終了後に自動で非表示にする
     const timer = setTimeout(() => {
       setIsVisible(false)
@@ -40,7 +51,7 @@ export default function GiftAnimation({ emoji, giftName, sender, onComplete }: G
       <div className="absolute inset-0 bg-black/30 animate-fade-in" />
 
       {/* パーティクル */}
-      {particles.map((particle) => (
+      {GIFT_PARTICLES.map((particle) => (
         <div
           key={particle.id}
           className="absolute text-2xl animate-float-up"
@@ -70,13 +81,13 @@ export default function GiftAnimation({ emoji, giftName, sender, onComplete }: G
 
         {/* きらめきエフェクト */}
         <div className="absolute -inset-8">
-          {[...Array(8)].map((_, i) => (
+          {SPARKLE_POSITIONS.map((sparkle, i) => (
             <div
               key={i}
               className="absolute w-2 h-2 bg-yellow-300 rounded-full animate-sparkle"
               style={{
-                top: `${20 + Math.random() * 60}%`,
-                left: `${20 + Math.random() * 60}%`,
+                top: sparkle.top,
+                left: sparkle.left,
                 animationDelay: `${i * 0.1}s`,
               }}
             />

--- a/components/community/MessageForm.tsx
+++ b/components/community/MessageForm.tsx
@@ -150,6 +150,7 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
           value={sender}
           onChange={(e) => setSender(e.target.value)}
           placeholder={t('yourName')}
+          aria-label={t('yourName')}
           style={{
             width: '100%',
             padding: '12px 15px',
@@ -169,6 +170,7 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
           value={message}
           onChange={(e) => setMessage(e.target.value)}
           placeholder={t('typeMessage')}
+          aria-label={t('messagePlaceholder')}
           rows={4}
           style={{
             width: '100%',
@@ -357,7 +359,14 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
 
       {/* アップロードの進行状況 */}
       {uploadProgress > 0 && uploadProgress < 100 && (
-        <div style={{ marginBottom: '15px' }}>
+        <div
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuenow={uploadProgress}
+          aria-valuemax={100}
+          aria-label={t('uploadProgress', { progress: uploadProgress })}
+          style={{ marginBottom: '15px' }}
+        >
           <div
             style={{
               height: '4px',
@@ -382,7 +391,7 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
       )}
 
       {error && (
-        <p style={{ color: '#dc3545', marginBottom: '15px', fontSize: '0.9rem' }}>{error}</p>
+        <p role="alert" style={{ color: '#dc3545', marginBottom: '15px', fontSize: '0.9rem' }}>{error}</p>
       )}
 
       <motion.button

--- a/components/community/TimeCapsule.tsx
+++ b/components/community/TimeCapsule.tsx
@@ -16,6 +16,16 @@ interface CapsuleItem {
   isUnlocked: boolean
 }
 
+interface TimeCapsuleRow {
+  id: string | number
+  sender: string
+  recipient?: string | null
+  message: string
+  photo_url?: string | null
+  unlock_date: string
+  created_at: string
+}
+
 // ローカル日付文字列（YYYY-MM-DD）をローカル時間 00:00:00 の Date オブジェクトに変換
 function parseLocalDate(dateStr: string): Date {
   const parts = dateStr.split('-').map(Number)
@@ -75,16 +85,16 @@ export function TimeCapsule({ onClose }: { onClose?: () => void }) {
 
       let remoteCapsules: CapsuleItem[] = []
       if (!error && data) {
-        remoteCapsules = data.map((c: any) => {
+        remoteCapsules = data.map((c: TimeCapsuleRow) => {
           const unlockTime = parseLocalDate(c.unlock_date)
           const isUnlocked = unlockTime <= now
           return {
             id: c.id,
             sender: c.sender,
-            recipient: c.recipient,
+            recipient: c.recipient ?? undefined,
             // 未開封時は内容を秘匿化
             message: isUnlocked ? c.message : '',
-            photoUrl: isUnlocked ? c.photo_url : undefined,
+            photoUrl: isUnlocked ? (c.photo_url ?? undefined) : undefined,
             unlockDate: c.unlock_date,
             createdAt: c.created_at,
             isUnlocked,

--- a/components/effects/Bats.tsx
+++ b/components/effects/Bats.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
+import { usePrefersReducedMotion } from '@/lib/hooks/useMediaQuery'
 
 interface BatsProps {
   active: boolean
@@ -21,6 +22,7 @@ interface Bat {
 
 export function Bats({ active, count = 8 }: BatsProps) {
   const [bats, setBats] = useState<Bat[]>([])
+  const prefersReducedMotion = usePrefersReducedMotion()
 
   const createBat = useCallback((): Bat => {
     const direction = Math.random() > 0.5 ? 'left' : 'right'
@@ -39,9 +41,11 @@ export function Bats({ active, count = 8 }: BatsProps) {
   }, [])
 
   useEffect(() => {
+    if (prefersReducedMotion) return
+
     if (!active) {
-      setBats([])
-      return
+      const raf = requestAnimationFrame(() => setBats([]))
+      return () => cancelAnimationFrame(raf)
     }
 
     const spawnBat = () => {
@@ -65,7 +69,10 @@ export function Bats({ active, count = 8 }: BatsProps) {
       clearInterval(interval)
       clearInterval(cleanup)
     }
-  }, [active, count, createBat])
+  }, [active, count, createBat, prefersReducedMotion])
+
+  // reduced-motion 時は描画もループも停止
+  if (prefersReducedMotion) return null
 
   if (!active) return null
 

--- a/components/effects/Bats.tsx
+++ b/components/effects/Bats.tsx
@@ -41,9 +41,7 @@ export function Bats({ active, count = 8 }: BatsProps) {
   }, [])
 
   useEffect(() => {
-    if (prefersReducedMotion) return
-
-    if (!active) {
+    if (!active || prefersReducedMotion) {
       const raf = requestAnimationFrame(() => setBats([]))
       return () => cancelAnimationFrame(raf)
     }

--- a/components/effects/ChristmasLights.tsx
+++ b/components/effects/ChristmasLights.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { useEffect, useState } from 'react'
 import { motion } from 'framer-motion'
 
 interface ChristmasLightsProps {
@@ -11,24 +10,14 @@ interface ChristmasLightsProps {
 const COLORS = ['#FF0000', '#00FF00', '#FFD700', '#0066FF', '#FF69B4', '#FFFFFF']
 
 export function ChristmasLights({ active, count = 30 }: ChristmasLightsProps) {
-  const [lights, setLights] = useState<{ id: number; x: number; color: string; delay: number }[]>([])
-
-  useEffect(() => {
-    if (!active) {
-      setLights([])
-      return
-    }
-
-    const newLights = Array.from({ length: count }, (_, i) => ({
-      id: i,
-      x: (i / count) * 100,
-      color: COLORS[i % COLORS.length],
-      delay: (i % 6) * 0.15,
-    }))
-    setLights(newLights)
-  }, [active, count])
-
   if (!active) return null
+
+  const lights = Array.from({ length: count }, (_, i) => ({
+    id: i,
+    x: (i / count) * 100,
+    color: COLORS[i % COLORS.length],
+    delay: (i % 6) * 0.15,
+  }))
 
   return (
     <div className="fixed top-0 left-0 right-0 pointer-events-none z-40">

--- a/components/effects/Confetti.tsx
+++ b/components/effects/Confetti.tsx
@@ -57,20 +57,27 @@ export default function Confetti({
   }, [colors])
 
   useEffect(() => {
-    if (prefersReducedMotion) return
+    if (prefersReducedMotion) {
+      if (isActive) {
+        onComplete?.()
+      }
+      return
+    }
 
     if (!isActive) {
       const raf = requestAnimationFrame(() => setPieces([]))
       return () => cancelAnimationFrame(raf)
     }
 
+    let initialRaf: number | null = null
+    let animationId: number | null = null
+
     // 初期状態のコンフェッティを生成
-    const initialRaf = requestAnimationFrame(() => {
+    initialRaf = requestAnimationFrame(() => {
       setPieces(Array.from({ length: particleCount }, (_, i) => createPiece(i)))
     })
 
     // アニメーションループ
-    let animationId: number
     let lastTime = performance.now()
 
     const animate = (currentTime: number) => {
@@ -96,14 +103,15 @@ export default function Confetti({
 
     // duration 経過後にアニメーションを停止
     const timeout = setTimeout(() => {
-      cancelAnimationFrame(animationId)
+      if (initialRaf) cancelAnimationFrame(initialRaf)
+      if (animationId) cancelAnimationFrame(animationId)
       setPieces([])
       onComplete?.()
     }, duration)
 
     return () => {
-      cancelAnimationFrame(initialRaf)
-      cancelAnimationFrame(animationId)
+      if (initialRaf) cancelAnimationFrame(initialRaf)
+      if (animationId) cancelAnimationFrame(animationId)
       clearTimeout(timeout)
     }
   }, [isActive, particleCount, duration, createPiece, onComplete, prefersReducedMotion])
@@ -187,14 +195,25 @@ interface ConfettiBurstProps {
 
 export function ConfettiBurst({ x, y, isActive, onComplete }: ConfettiBurstProps) {
   const [pieces, setPieces] = useState<ConfettiPiece[]>([])
+  const prefersReducedMotion = usePrefersReducedMotion()
 
   useEffect(() => {
+    if (prefersReducedMotion) {
+      if (isActive) {
+        onComplete?.()
+      }
+      return
+    }
+
     if (!isActive) {
       const raf = requestAnimationFrame(() => setPieces([]))
       return () => cancelAnimationFrame(raf)
     }
 
-    const burstRaf = requestAnimationFrame(() => {
+    let burstRaf: number | null = null
+    let animationId: number | null = null
+
+    burstRaf = requestAnimationFrame(() => {
       const burstPieces: ConfettiPiece[] = Array.from({ length: 50 }, (_, i) => {
         const angle = (i / 50) * Math.PI * 2
         const velocity = 5 + Math.random() * 10
@@ -214,7 +233,6 @@ export function ConfettiBurst({ x, y, isActive, onComplete }: ConfettiBurstProps
       setPieces(burstPieces)
     })
 
-    let animationId: number
     const animate = () => {
       setPieces((prev) =>
         prev
@@ -237,19 +255,20 @@ export function ConfettiBurst({ x, y, isActive, onComplete }: ConfettiBurstProps
     animationId = requestAnimationFrame(animate)
 
     const timeout = setTimeout(() => {
-      cancelAnimationFrame(animationId)
+      if (burstRaf) cancelAnimationFrame(burstRaf)
+      if (animationId) cancelAnimationFrame(animationId)
       setPieces([])
       onComplete?.()
     }, 3000)
 
     return () => {
-      cancelAnimationFrame(burstRaf)
-      cancelAnimationFrame(animationId)
+      if (burstRaf) cancelAnimationFrame(burstRaf)
+      if (animationId) cancelAnimationFrame(animationId)
       clearTimeout(timeout)
     }
-  }, [isActive, x, y, onComplete])
+  }, [isActive, x, y, onComplete, prefersReducedMotion, pieces.length])
 
-  if (pieces.length === 0) return null
+  if (prefersReducedMotion || pieces.length === 0) return null
 
   return (
     <div className="fixed inset-0 pointer-events-none z-50 overflow-hidden">

--- a/components/effects/Confetti.tsx
+++ b/components/effects/Confetti.tsx
@@ -69,9 +69,14 @@ export default function Confetti({
   }, [isActive])
 
   useEffect(() => {
-    if (!isActive || prefersReducedMotion) {
+    if (!isActive) {
       const raf = requestAnimationFrame(() => setPieces([]))
-      if (prefersReducedMotion && !completedRef.current) {
+      return () => cancelAnimationFrame(raf)
+    }
+
+    if (prefersReducedMotion) {
+      const raf = requestAnimationFrame(() => setPieces([]))
+      if (!completedRef.current) {
         completedRef.current = true
         onCompleteRef.current?.()
       }
@@ -84,21 +89,24 @@ export default function Confetti({
 
     let initialRaf: number | null = null
     let animationId: number | null = null
+    let currentPieces: ConfettiPiece[] = []
+    let lastTime = performance.now()
+    let isRunning = true
 
     // 初期状態のコンフェッティを生成
     initialRaf = requestAnimationFrame(() => {
-      setPieces(Array.from({ length: particleCount }, (_, i) => createPiece(i)))
-    })
+      if (!isRunning) return
+      currentPieces = Array.from({ length: particleCount }, (_, i) => createPiece(i))
+      setPieces(currentPieces)
 
-    // アニメーションループ
-    let lastTime = performance.now()
+      const step = (currentTime: number) => {
+        if (!isRunning) return
+        if (currentPieces.length === 0) return
 
-    const animate = (currentTime: number) => {
-      const deltaTime = (currentTime - lastTime) / 16.67 // 約60fps基準に正規化
-      lastTime = currentTime
+        const deltaTime = (currentTime - lastTime) / 16.67 // 約60fps基準に正規化
+        lastTime = currentTime
 
-      setPieces((prev) =>
-        prev
+        currentPieces = currentPieces
           .map((piece) => ({
             ...piece,
             x: piece.x + piece.velocityX * deltaTime * 0.5,
@@ -107,15 +115,23 @@ export default function Confetti({
             velocityY: piece.velocityY + 0.1 * deltaTime, // 重力
           }))
           .filter((piece) => piece.y < 120) // 画面外に落ちたピースを除去
-      )
 
-      animationId = requestAnimationFrame(animate)
-    }
+        setPieces(currentPieces)
 
-    animationId = requestAnimationFrame(animate)
+        if (isRunning && currentPieces.length > 0) {
+          animationId = requestAnimationFrame(step)
+        }
+      }
+
+      lastTime = performance.now()
+      if (isRunning && currentPieces.length > 0) {
+        animationId = requestAnimationFrame(step)
+      }
+    })
 
     // duration 経過後にアニメーションを停止
     const timeout = setTimeout(() => {
+      isRunning = false
       if (initialRaf !== null) cancelAnimationFrame(initialRaf)
       if (animationId !== null) cancelAnimationFrame(animationId)
       setPieces([])
@@ -126,6 +142,7 @@ export default function Confetti({
     }, duration)
 
     return () => {
+      isRunning = false
       if (initialRaf !== null) cancelAnimationFrame(initialRaf)
       if (animationId !== null) cancelAnimationFrame(animationId)
       clearTimeout(timeout)
@@ -226,9 +243,14 @@ export function ConfettiBurst({ x, y, isActive, onComplete }: ConfettiBurstProps
   }, [isActive])
 
   useEffect(() => {
-    if (!isActive || prefersReducedMotion) {
+    if (!isActive) {
       const raf = requestAnimationFrame(() => setPieces([]))
-      if (prefersReducedMotion && !completedRef.current) {
+      return () => cancelAnimationFrame(raf)
+    }
+
+    if (prefersReducedMotion) {
+      const raf = requestAnimationFrame(() => setPieces([]))
+      if (!completedRef.current) {
         completedRef.current = true
         onCompleteRef.current?.()
       }
@@ -241,9 +263,12 @@ export function ConfettiBurst({ x, y, isActive, onComplete }: ConfettiBurstProps
 
     let burstRaf: number | null = null
     let animationId: number | null = null
+    let currentPieces: ConfettiPiece[] = []
+    let isRunning = true
 
     burstRaf = requestAnimationFrame(() => {
-      const burstPieces: ConfettiPiece[] = Array.from({ length: 50 }, (_, i) => {
+      if (!isRunning) return
+      currentPieces = Array.from({ length: 50 }, (_, i) => {
         const angle = (i / 50) * Math.PI * 2
         const velocity = 5 + Math.random() * 10
         return {
@@ -259,13 +284,13 @@ export function ConfettiBurst({ x, y, isActive, onComplete }: ConfettiBurstProps
           shape: 'square',
         }
       })
-      setPieces(burstPieces)
-    })
+      setPieces(currentPieces)
 
-    const animate = () => {
-      setPieces((prev) => {
-        if (prev.length === 0) return prev
-        const nextPieces = prev
+      const step = () => {
+        if (!isRunning) return
+        if (currentPieces.length === 0) return
+
+        currentPieces = currentPieces
           .map((piece) => ({
             ...piece,
             x: piece.x + piece.velocityX,
@@ -276,16 +301,20 @@ export function ConfettiBurst({ x, y, isActive, onComplete }: ConfettiBurstProps
           }))
           .filter((piece) => piece.y < window.innerHeight + 50)
 
-        if (nextPieces.length > 0) {
-          animationId = requestAnimationFrame(animate)
-        }
-        return nextPieces
-      })
-    }
+        setPieces(currentPieces)
 
-    animationId = requestAnimationFrame(animate)
+        if (isRunning && currentPieces.length > 0) {
+          animationId = requestAnimationFrame(step)
+        }
+      }
+
+      if (isRunning && currentPieces.length > 0) {
+        animationId = requestAnimationFrame(step)
+      }
+    })
 
     const timeout = setTimeout(() => {
+      isRunning = false
       if (burstRaf !== null) cancelAnimationFrame(burstRaf)
       if (animationId !== null) cancelAnimationFrame(animationId)
       setPieces([])
@@ -296,6 +325,7 @@ export function ConfettiBurst({ x, y, isActive, onComplete }: ConfettiBurstProps
     }, 3000)
 
     return () => {
+      isRunning = false
       if (burstRaf !== null) cancelAnimationFrame(burstRaf)
       if (animationId !== null) cancelAnimationFrame(animationId)
       clearTimeout(timeout)

--- a/components/effects/Confetti.tsx
+++ b/components/effects/Confetti.tsx
@@ -111,8 +111,8 @@ export default function Confetti({
 
     // duration 経過後にアニメーションを停止
     const timeout = setTimeout(() => {
-      if (initialRaf) cancelAnimationFrame(initialRaf)
-      if (animationId) cancelAnimationFrame(animationId)
+      if (initialRaf !== null) cancelAnimationFrame(initialRaf)
+      if (animationId !== null) cancelAnimationFrame(animationId)
       setPieces([])
       if (!completedRef.current) {
         completedRef.current = true
@@ -121,8 +121,8 @@ export default function Confetti({
     }, duration)
 
     return () => {
-      if (initialRaf) cancelAnimationFrame(initialRaf)
-      if (animationId) cancelAnimationFrame(animationId)
+      if (initialRaf !== null) cancelAnimationFrame(initialRaf)
+      if (animationId !== null) cancelAnimationFrame(animationId)
       clearTimeout(timeout)
     }
   }, [isActive, particleCount, duration, createPiece, onComplete, prefersReducedMotion])
@@ -273,8 +273,8 @@ export function ConfettiBurst({ x, y, isActive, onComplete }: ConfettiBurstProps
     animationId = requestAnimationFrame(animate)
 
     const timeout = setTimeout(() => {
-      if (burstRaf) cancelAnimationFrame(burstRaf)
-      if (animationId) cancelAnimationFrame(animationId)
+      if (burstRaf !== null) cancelAnimationFrame(burstRaf)
+      if (animationId !== null) cancelAnimationFrame(animationId)
       setPieces([])
       if (!completedRef.current) {
         completedRef.current = true
@@ -283,8 +283,8 @@ export function ConfettiBurst({ x, y, isActive, onComplete }: ConfettiBurstProps
     }, 3000)
 
     return () => {
-      if (burstRaf) cancelAnimationFrame(burstRaf)
-      if (animationId) cancelAnimationFrame(animationId)
+      if (burstRaf !== null) cancelAnimationFrame(burstRaf)
+      if (animationId !== null) cancelAnimationFrame(animationId)
       clearTimeout(timeout)
     }
   }, [isActive, x, y, onComplete, prefersReducedMotion])

--- a/components/effects/Confetti.tsx
+++ b/components/effects/Confetti.tsx
@@ -49,10 +49,25 @@ function useConfettiAnimation({
   const prefersReducedMotion = usePrefersReducedMotion()
   const completedRef = useRef(false)
   const onCompleteRef = useRef(onComplete)
+  const createInitialPiecesRef = useRef(createInitialPieces)
+  const updatePiecesRef = useRef(updatePieces)
+  const durationRef = useRef(duration)
 
   useEffect(() => {
     onCompleteRef.current = onComplete
   }, [onComplete])
+
+  useEffect(() => {
+    createInitialPiecesRef.current = createInitialPieces
+  }, [createInitialPieces])
+
+  useEffect(() => {
+    updatePiecesRef.current = updatePieces
+  }, [updatePieces])
+
+  useEffect(() => {
+    durationRef.current = duration
+  }, [duration])
 
   useEffect(() => {
     if (!isActive) {
@@ -87,7 +102,7 @@ function useConfettiAnimation({
 
     initialRaf = requestAnimationFrame(() => {
       if (!isRunning) return
-      currentPieces = createInitialPieces()
+      currentPieces = createInitialPiecesRef.current()
       setPieces(currentPieces)
 
       const step = (currentTime: number) => {
@@ -97,7 +112,7 @@ function useConfettiAnimation({
         const deltaTime = (currentTime - lastTime) / 16.67
         lastTime = currentTime
 
-        currentPieces = updatePieces(currentPieces, deltaTime)
+        currentPieces = updatePiecesRef.current(currentPieces, deltaTime)
         setPieces(currentPieces)
 
         if (isRunning && currentPieces.length > 0) {
@@ -120,7 +135,7 @@ function useConfettiAnimation({
         completedRef.current = true
         onCompleteRef.current?.()
       }
-    }, duration)
+    }, durationRef.current)
 
     return () => {
       isRunning = false
@@ -128,7 +143,7 @@ function useConfettiAnimation({
       if (animationId !== null) cancelAnimationFrame(animationId)
       clearTimeout(timeout)
     }
-  }, [isActive, duration, createInitialPieces, updatePieces, prefersReducedMotion])
+  }, [isActive, prefersReducedMotion])
 
   return { pieces, prefersReducedMotion }
 }

--- a/components/effects/Confetti.tsx
+++ b/components/effects/Confetti.tsx
@@ -69,17 +69,13 @@ export default function Confetti({
   }, [isActive])
 
   useEffect(() => {
-    if (!isActive) {
+    if (!isActive || prefersReducedMotion) {
       const raf = requestAnimationFrame(() => setPieces([]))
-      return () => cancelAnimationFrame(raf)
-    }
-
-    if (prefersReducedMotion) {
-      if (!completedRef.current) {
+      if (prefersReducedMotion && !completedRef.current) {
         completedRef.current = true
         onCompleteRef.current?.()
       }
-      return
+      return () => cancelAnimationFrame(raf)
     }
 
     if (completedRef.current) {
@@ -230,17 +226,13 @@ export function ConfettiBurst({ x, y, isActive, onComplete }: ConfettiBurstProps
   }, [isActive])
 
   useEffect(() => {
-    if (!isActive) {
+    if (!isActive || prefersReducedMotion) {
       const raf = requestAnimationFrame(() => setPieces([]))
-      return () => cancelAnimationFrame(raf)
-    }
-
-    if (prefersReducedMotion) {
-      if (!completedRef.current) {
+      if (prefersReducedMotion && !completedRef.current) {
         completedRef.current = true
         onCompleteRef.current?.()
       }
-      return
+      return () => cancelAnimationFrame(raf)
     }
 
     if (completedRef.current) {
@@ -273,7 +265,7 @@ export function ConfettiBurst({ x, y, isActive, onComplete }: ConfettiBurstProps
     const animate = () => {
       setPieces((prev) => {
         if (prev.length === 0) return prev
-        return prev
+        const nextPieces = prev
           .map((piece) => ({
             ...piece,
             x: piece.x + piece.velocityX,
@@ -283,9 +275,12 @@ export function ConfettiBurst({ x, y, isActive, onComplete }: ConfettiBurstProps
             velocityX: piece.velocityX * 0.98,
           }))
           .filter((piece) => piece.y < window.innerHeight + 50)
-      })
 
-      animationId = requestAnimationFrame(animate)
+        if (nextPieces.length > 0) {
+          animationId = requestAnimationFrame(animate)
+        }
+        return nextPieces
+      })
     }
 
     animationId = requestAnimationFrame(animate)

--- a/components/effects/Confetti.tsx
+++ b/components/effects/Confetti.tsx
@@ -39,7 +39,7 @@ export default function Confetti({
 }: ConfettiProps) {
   const [pieces, setPieces] = useState<ConfettiPiece[]>([])
   const prefersReducedMotion = usePrefersReducedMotion()
-  const wasActiveRef = useRef(false)
+  const completedRef = useRef(false)
 
   const createPiece = useCallback((id: number): ConfettiPiece => {
     const shapes: ConfettiPiece['shape'][] = ['square', 'circle', 'triangle', 'star']
@@ -58,18 +58,23 @@ export default function Confetti({
   }, [colors])
 
   useEffect(() => {
-    if (prefersReducedMotion) {
-      if (isActive && !wasActiveRef.current) {
-        onComplete?.()
-      }
-      wasActiveRef.current = isActive
-      return
+    if (!isActive) {
+      completedRef.current = false
     }
-    wasActiveRef.current = isActive
+  }, [isActive])
 
+  useEffect(() => {
     if (!isActive) {
       const raf = requestAnimationFrame(() => setPieces([]))
       return () => cancelAnimationFrame(raf)
+    }
+
+    if (prefersReducedMotion) {
+      if (!completedRef.current) {
+        completedRef.current = true
+        onComplete?.()
+      }
+      return
     }
 
     let initialRaf: number | null = null
@@ -109,7 +114,10 @@ export default function Confetti({
       if (initialRaf) cancelAnimationFrame(initialRaf)
       if (animationId) cancelAnimationFrame(animationId)
       setPieces([])
-      onComplete?.()
+      if (!completedRef.current) {
+        completedRef.current = true
+        onComplete?.()
+      }
     }, duration)
 
     return () => {
@@ -199,21 +207,26 @@ interface ConfettiBurstProps {
 export function ConfettiBurst({ x, y, isActive, onComplete }: ConfettiBurstProps) {
   const [pieces, setPieces] = useState<ConfettiPiece[]>([])
   const prefersReducedMotion = usePrefersReducedMotion()
-  const wasActiveRef = useRef(false)
+  const completedRef = useRef(false)
 
   useEffect(() => {
-    if (prefersReducedMotion) {
-      if (isActive && !wasActiveRef.current) {
-        onComplete?.()
-      }
-      wasActiveRef.current = isActive
-      return
+    if (!isActive) {
+      completedRef.current = false
     }
-    wasActiveRef.current = isActive
+  }, [isActive])
 
+  useEffect(() => {
     if (!isActive) {
       const raf = requestAnimationFrame(() => setPieces([]))
       return () => cancelAnimationFrame(raf)
+    }
+
+    if (prefersReducedMotion) {
+      if (!completedRef.current) {
+        completedRef.current = true
+        onComplete?.()
+      }
+      return
     }
 
     let burstRaf: number | null = null
@@ -263,7 +276,10 @@ export function ConfettiBurst({ x, y, isActive, onComplete }: ConfettiBurstProps
       if (burstRaf) cancelAnimationFrame(burstRaf)
       if (animationId) cancelAnimationFrame(animationId)
       setPieces([])
-      onComplete?.()
+      if (!completedRef.current) {
+        completedRef.current = true
+        onComplete?.()
+      }
     }, 3000)
 
     return () => {

--- a/components/effects/Confetti.tsx
+++ b/components/effects/Confetti.tsx
@@ -40,6 +40,11 @@ export default function Confetti({
   const [pieces, setPieces] = useState<ConfettiPiece[]>([])
   const prefersReducedMotion = usePrefersReducedMotion()
   const completedRef = useRef(false)
+  const onCompleteRef = useRef(onComplete)
+
+  useEffect(() => {
+    onCompleteRef.current = onComplete
+  }, [onComplete])
 
   const createPiece = useCallback((id: number): ConfettiPiece => {
     const shapes: ConfettiPiece['shape'][] = ['square', 'circle', 'triangle', 'star']
@@ -72,8 +77,12 @@ export default function Confetti({
     if (prefersReducedMotion) {
       if (!completedRef.current) {
         completedRef.current = true
-        onComplete?.()
+        onCompleteRef.current?.()
       }
+      return
+    }
+
+    if (completedRef.current) {
       return
     }
 
@@ -116,7 +125,7 @@ export default function Confetti({
       setPieces([])
       if (!completedRef.current) {
         completedRef.current = true
-        onComplete?.()
+        onCompleteRef.current?.()
       }
     }, duration)
 
@@ -125,7 +134,7 @@ export default function Confetti({
       if (animationId !== null) cancelAnimationFrame(animationId)
       clearTimeout(timeout)
     }
-  }, [isActive, particleCount, duration, createPiece, onComplete, prefersReducedMotion])
+  }, [isActive, particleCount, duration, createPiece, prefersReducedMotion])
 
   // reduced-motion 時は描画もループも停止
   if (prefersReducedMotion) return null
@@ -208,6 +217,11 @@ export function ConfettiBurst({ x, y, isActive, onComplete }: ConfettiBurstProps
   const [pieces, setPieces] = useState<ConfettiPiece[]>([])
   const prefersReducedMotion = usePrefersReducedMotion()
   const completedRef = useRef(false)
+  const onCompleteRef = useRef(onComplete)
+
+  useEffect(() => {
+    onCompleteRef.current = onComplete
+  }, [onComplete])
 
   useEffect(() => {
     if (!isActive) {
@@ -224,8 +238,12 @@ export function ConfettiBurst({ x, y, isActive, onComplete }: ConfettiBurstProps
     if (prefersReducedMotion) {
       if (!completedRef.current) {
         completedRef.current = true
-        onComplete?.()
+        onCompleteRef.current?.()
       }
+      return
+    }
+
+    if (completedRef.current) {
       return
     }
 
@@ -278,7 +296,7 @@ export function ConfettiBurst({ x, y, isActive, onComplete }: ConfettiBurstProps
       setPieces([])
       if (!completedRef.current) {
         completedRef.current = true
-        onComplete?.()
+        onCompleteRef.current?.()
       }
     }, 3000)
 
@@ -287,7 +305,7 @@ export function ConfettiBurst({ x, y, isActive, onComplete }: ConfettiBurstProps
       if (animationId !== null) cancelAnimationFrame(animationId)
       clearTimeout(timeout)
     }
-  }, [isActive, x, y, onComplete, prefersReducedMotion])
+  }, [isActive, x, y, prefersReducedMotion])
 
   if (prefersReducedMotion || pieces.length === 0) return null
 

--- a/components/effects/Confetti.tsx
+++ b/components/effects/Confetti.tsx
@@ -277,15 +277,16 @@ export function ConfettiBurst({ x, y, isActive, onComplete }: ConfettiBurstProps
     })
   }, [x, y])
 
-  const updatePieces = useCallback((current: ConfettiPiece[]) => {
+  const updatePieces = useCallback((current: ConfettiPiece[], deltaTime: number) => {
+    const drag = Math.pow(0.98, deltaTime)
     return current
       .map((piece) => ({
         ...piece,
-        x: piece.x + piece.velocityX,
-        y: piece.y + piece.velocityY,
-        rotation: piece.rotation + piece.rotationSpeed,
-        velocityY: piece.velocityY + 0.5,
-        velocityX: piece.velocityX * 0.98,
+        x: piece.x + piece.velocityX * deltaTime,
+        y: piece.y + piece.velocityY * deltaTime,
+        rotation: piece.rotation + piece.rotationSpeed * deltaTime,
+        velocityY: piece.velocityY + 0.5 * deltaTime,
+        velocityX: piece.velocityX * drag,
       }))
       .filter((piece) => piece.y < window.innerHeight + 50)
   }, [])

--- a/components/effects/Confetti.tsx
+++ b/components/effects/Confetti.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState, useCallback } from 'react'
+import { usePrefersReducedMotion } from '@/lib/hooks/useMediaQuery'
 
 interface ConfettiPiece {
   id: number
@@ -37,6 +38,7 @@ export default function Confetti({
   onComplete,
 }: ConfettiProps) {
   const [pieces, setPieces] = useState<ConfettiPiece[]>([])
+  const prefersReducedMotion = usePrefersReducedMotion()
 
   const createPiece = useCallback((id: number): ConfettiPiece => {
     const shapes: ConfettiPiece['shape'][] = ['square', 'circle', 'triangle', 'star']
@@ -55,14 +57,17 @@ export default function Confetti({
   }, [colors])
 
   useEffect(() => {
+    if (prefersReducedMotion) return
+
     if (!isActive) {
-      setPieces([])
-      return
+      const raf = requestAnimationFrame(() => setPieces([]))
+      return () => cancelAnimationFrame(raf)
     }
 
     // 初期状態のコンフェッティを生成
-    const initialPieces = Array.from({ length: particleCount }, (_, i) => createPiece(i))
-    setPieces(initialPieces)
+    const initialRaf = requestAnimationFrame(() => {
+      setPieces(Array.from({ length: particleCount }, (_, i) => createPiece(i)))
+    })
 
     // アニメーションループ
     let animationId: number
@@ -97,10 +102,14 @@ export default function Confetti({
     }, duration)
 
     return () => {
+      cancelAnimationFrame(initialRaf)
       cancelAnimationFrame(animationId)
       clearTimeout(timeout)
     }
-  }, [isActive, particleCount, duration, createPiece, onComplete])
+  }, [isActive, particleCount, duration, createPiece, onComplete, prefersReducedMotion])
+
+  // reduced-motion 時は描画もループも停止
+  if (prefersReducedMotion) return null
 
   if (!isActive && pieces.length === 0) return null
 
@@ -181,28 +190,29 @@ export function ConfettiBurst({ x, y, isActive, onComplete }: ConfettiBurstProps
 
   useEffect(() => {
     if (!isActive) {
-      setPieces([])
-      return
+      const raf = requestAnimationFrame(() => setPieces([]))
+      return () => cancelAnimationFrame(raf)
     }
 
-    const burstPieces: ConfettiPiece[] = Array.from({ length: 50 }, (_, i) => {
-      const angle = (i / 50) * Math.PI * 2
-      const velocity = 5 + Math.random() * 10
-      return {
-        id: i,
-        x,
-        y,
-        rotation: Math.random() * 360,
-        color: defaultColors[Math.floor(Math.random() * defaultColors.length)],
-        size: 6 + Math.random() * 6,
-        velocityX: Math.cos(angle) * velocity,
-        velocityY: Math.sin(angle) * velocity - 5,
-        rotationSpeed: (Math.random() - 0.5) * 15,
-        shape: 'square',
-      }
+    const burstRaf = requestAnimationFrame(() => {
+      const burstPieces: ConfettiPiece[] = Array.from({ length: 50 }, (_, i) => {
+        const angle = (i / 50) * Math.PI * 2
+        const velocity = 5 + Math.random() * 10
+        return {
+          id: i,
+          x,
+          y,
+          rotation: Math.random() * 360,
+          color: defaultColors[Math.floor(Math.random() * defaultColors.length)],
+          size: 6 + Math.random() * 6,
+          velocityX: Math.cos(angle) * velocity,
+          velocityY: Math.sin(angle) * velocity - 5,
+          rotationSpeed: (Math.random() - 0.5) * 15,
+          shape: 'square',
+        }
+      })
+      setPieces(burstPieces)
     })
-
-    setPieces(burstPieces)
 
     let animationId: number
     const animate = () => {
@@ -233,6 +243,7 @@ export function ConfettiBurst({ x, y, isActive, onComplete }: ConfettiBurstProps
     }, 3000)
 
     return () => {
+      cancelAnimationFrame(burstRaf)
       cancelAnimationFrame(animationId)
       clearTimeout(timeout)
     }

--- a/components/effects/Confetti.tsx
+++ b/components/effects/Confetti.tsx
@@ -30,13 +30,21 @@ const defaultColors = [
   '#BB8FCE', '#85C1E9', '#F8B500', '#FF69B4',
 ]
 
-export default function Confetti({
+interface ConfettiAnimationConfig {
+  isActive: boolean
+  duration: number
+  onComplete?: () => void
+  createInitialPieces: () => ConfettiPiece[]
+  updatePieces: (pieces: ConfettiPiece[], deltaTime: number) => ConfettiPiece[]
+}
+
+function useConfettiAnimation({
   isActive,
-  duration = 5000,
-  particleCount = 150,
-  colors = defaultColors,
+  duration,
   onComplete,
-}: ConfettiProps) {
+  createInitialPieces,
+  updatePieces,
+}: ConfettiAnimationConfig) {
   const [pieces, setPieces] = useState<ConfettiPiece[]>([])
   const prefersReducedMotion = usePrefersReducedMotion()
   const completedRef = useRef(false)
@@ -45,22 +53,6 @@ export default function Confetti({
   useEffect(() => {
     onCompleteRef.current = onComplete
   }, [onComplete])
-
-  const createPiece = useCallback((id: number): ConfettiPiece => {
-    const shapes: ConfettiPiece['shape'][] = ['square', 'circle', 'triangle', 'star']
-    return {
-      id,
-      x: Math.random() * 100,
-      y: -10,
-      rotation: Math.random() * 360,
-      color: colors[Math.floor(Math.random() * colors.length)],
-      size: 8 + Math.random() * 8,
-      velocityX: (Math.random() - 0.5) * 4,
-      velocityY: 2 + Math.random() * 3,
-      rotationSpeed: (Math.random() - 0.5) * 10,
-      shape: shapes[Math.floor(Math.random() * shapes.length)],
-    }
-  }, [colors])
 
   useEffect(() => {
     if (!isActive) {
@@ -93,29 +85,19 @@ export default function Confetti({
     let lastTime = performance.now()
     let isRunning = true
 
-    // 初期状態のコンフェッティを生成
     initialRaf = requestAnimationFrame(() => {
       if (!isRunning) return
-      currentPieces = Array.from({ length: particleCount }, (_, i) => createPiece(i))
+      currentPieces = createInitialPieces()
       setPieces(currentPieces)
 
       const step = (currentTime: number) => {
         if (!isRunning) return
         if (currentPieces.length === 0) return
 
-        const deltaTime = (currentTime - lastTime) / 16.67 // 約60fps基準に正規化
+        const deltaTime = (currentTime - lastTime) / 16.67
         lastTime = currentTime
 
-        currentPieces = currentPieces
-          .map((piece) => ({
-            ...piece,
-            x: piece.x + piece.velocityX * deltaTime * 0.5,
-            y: piece.y + piece.velocityY * deltaTime * 0.5,
-            rotation: piece.rotation + piece.rotationSpeed * deltaTime,
-            velocityY: piece.velocityY + 0.1 * deltaTime, // 重力
-          }))
-          .filter((piece) => piece.y < 120) // 画面外に落ちたピースを除去
-
+        currentPieces = updatePieces(currentPieces, deltaTime)
         setPieces(currentPieces)
 
         if (isRunning && currentPieces.length > 0) {
@@ -129,7 +111,6 @@ export default function Confetti({
       }
     })
 
-    // duration 経過後にアニメーションを停止
     const timeout = setTimeout(() => {
       isRunning = false
       if (initialRaf !== null) cancelAnimationFrame(initialRaf)
@@ -147,7 +128,57 @@ export default function Confetti({
       if (animationId !== null) cancelAnimationFrame(animationId)
       clearTimeout(timeout)
     }
-  }, [isActive, particleCount, duration, createPiece, prefersReducedMotion])
+  }, [isActive, duration, createInitialPieces, updatePieces, prefersReducedMotion])
+
+  return { pieces, prefersReducedMotion }
+}
+
+export default function Confetti({
+  isActive,
+  duration = 5000,
+  particleCount = 150,
+  colors = defaultColors,
+  onComplete,
+}: ConfettiProps) {
+  const createPiece = useCallback((id: number): ConfettiPiece => {
+    const shapes: ConfettiPiece['shape'][] = ['square', 'circle', 'triangle', 'star']
+    return {
+      id,
+      x: Math.random() * 100,
+      y: -10,
+      rotation: Math.random() * 360,
+      color: colors[Math.floor(Math.random() * colors.length)],
+      size: 8 + Math.random() * 8,
+      velocityX: (Math.random() - 0.5) * 4,
+      velocityY: 2 + Math.random() * 3,
+      rotationSpeed: (Math.random() - 0.5) * 10,
+      shape: shapes[Math.floor(Math.random() * shapes.length)],
+    }
+  }, [colors])
+
+  const createInitialPieces = useCallback(() => {
+    return Array.from({ length: particleCount }, (_, i) => createPiece(i))
+  }, [particleCount, createPiece])
+
+  const updatePieces = useCallback((current: ConfettiPiece[], deltaTime: number) => {
+    return current
+      .map((piece) => ({
+        ...piece,
+        x: piece.x + piece.velocityX * deltaTime * 0.5,
+        y: piece.y + piece.velocityY * deltaTime * 0.5,
+        rotation: piece.rotation + piece.rotationSpeed * deltaTime,
+        velocityY: piece.velocityY + 0.1 * deltaTime,
+      }))
+      .filter((piece) => piece.y < 120)
+  }, [])
+
+  const { pieces, prefersReducedMotion } = useConfettiAnimation({
+    isActive,
+    duration,
+    onComplete,
+    createInitialPieces,
+    updatePieces,
+  })
 
   // reduced-motion 時は描画もループも停止
   if (prefersReducedMotion) return null
@@ -227,110 +258,45 @@ interface ConfettiBurstProps {
 }
 
 export function ConfettiBurst({ x, y, isActive, onComplete }: ConfettiBurstProps) {
-  const [pieces, setPieces] = useState<ConfettiPiece[]>([])
-  const prefersReducedMotion = usePrefersReducedMotion()
-  const completedRef = useRef(false)
-  const onCompleteRef = useRef(onComplete)
-
-  useEffect(() => {
-    onCompleteRef.current = onComplete
-  }, [onComplete])
-
-  useEffect(() => {
-    if (!isActive) {
-      completedRef.current = false
-    }
-  }, [isActive])
-
-  useEffect(() => {
-    if (!isActive) {
-      const raf = requestAnimationFrame(() => setPieces([]))
-      return () => cancelAnimationFrame(raf)
-    }
-
-    if (prefersReducedMotion) {
-      const raf = requestAnimationFrame(() => setPieces([]))
-      if (!completedRef.current) {
-        completedRef.current = true
-        onCompleteRef.current?.()
-      }
-      return () => cancelAnimationFrame(raf)
-    }
-
-    if (completedRef.current) {
-      return
-    }
-
-    let burstRaf: number | null = null
-    let animationId: number | null = null
-    let currentPieces: ConfettiPiece[] = []
-    let isRunning = true
-
-    burstRaf = requestAnimationFrame(() => {
-      if (!isRunning) return
-      currentPieces = Array.from({ length: 50 }, (_, i) => {
-        const angle = (i / 50) * Math.PI * 2
-        const velocity = 5 + Math.random() * 10
-        return {
-          id: i,
-          x,
-          y,
-          rotation: Math.random() * 360,
-          color: defaultColors[Math.floor(Math.random() * defaultColors.length)],
-          size: 6 + Math.random() * 6,
-          velocityX: Math.cos(angle) * velocity,
-          velocityY: Math.sin(angle) * velocity - 5,
-          rotationSpeed: (Math.random() - 0.5) * 15,
-          shape: 'square',
-        }
-      })
-      setPieces(currentPieces)
-
-      const step = () => {
-        if (!isRunning) return
-        if (currentPieces.length === 0) return
-
-        currentPieces = currentPieces
-          .map((piece) => ({
-            ...piece,
-            x: piece.x + piece.velocityX,
-            y: piece.y + piece.velocityY,
-            rotation: piece.rotation + piece.rotationSpeed,
-            velocityY: piece.velocityY + 0.5,
-            velocityX: piece.velocityX * 0.98,
-          }))
-          .filter((piece) => piece.y < window.innerHeight + 50)
-
-        setPieces(currentPieces)
-
-        if (isRunning && currentPieces.length > 0) {
-          animationId = requestAnimationFrame(step)
-        }
-      }
-
-      if (isRunning && currentPieces.length > 0) {
-        animationId = requestAnimationFrame(step)
+  const createInitialPieces = useCallback(() => {
+    return Array.from({ length: 50 }, (_, i) => {
+      const angle = (i / 50) * Math.PI * 2
+      const velocity = 5 + Math.random() * 10
+      return {
+        id: i,
+        x,
+        y,
+        rotation: Math.random() * 360,
+        color: defaultColors[Math.floor(Math.random() * defaultColors.length)],
+        size: 6 + Math.random() * 6,
+        velocityX: Math.cos(angle) * velocity,
+        velocityY: Math.sin(angle) * velocity - 5,
+        rotationSpeed: (Math.random() - 0.5) * 15,
+        shape: 'square' as const,
       }
     })
+  }, [x, y])
 
-    const timeout = setTimeout(() => {
-      isRunning = false
-      if (burstRaf !== null) cancelAnimationFrame(burstRaf)
-      if (animationId !== null) cancelAnimationFrame(animationId)
-      setPieces([])
-      if (!completedRef.current) {
-        completedRef.current = true
-        onCompleteRef.current?.()
-      }
-    }, 3000)
+  const updatePieces = useCallback((current: ConfettiPiece[]) => {
+    return current
+      .map((piece) => ({
+        ...piece,
+        x: piece.x + piece.velocityX,
+        y: piece.y + piece.velocityY,
+        rotation: piece.rotation + piece.rotationSpeed,
+        velocityY: piece.velocityY + 0.5,
+        velocityX: piece.velocityX * 0.98,
+      }))
+      .filter((piece) => piece.y < window.innerHeight + 50)
+  }, [])
 
-    return () => {
-      isRunning = false
-      if (burstRaf !== null) cancelAnimationFrame(burstRaf)
-      if (animationId !== null) cancelAnimationFrame(animationId)
-      clearTimeout(timeout)
-    }
-  }, [isActive, x, y, prefersReducedMotion])
+  const { pieces, prefersReducedMotion } = useConfettiAnimation({
+    isActive,
+    duration: 3000,
+    onComplete,
+    createInitialPieces,
+    updatePieces,
+  })
 
   if (prefersReducedMotion || pieces.length === 0) return null
 

--- a/components/effects/Confetti.tsx
+++ b/components/effects/Confetti.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, useRef } from 'react'
 import { usePrefersReducedMotion } from '@/lib/hooks/useMediaQuery'
 
 interface ConfettiPiece {
@@ -39,13 +39,14 @@ export default function Confetti({
 }: ConfettiProps) {
   const [pieces, setPieces] = useState<ConfettiPiece[]>([])
   const prefersReducedMotion = usePrefersReducedMotion()
+  const wasActiveRef = useRef(false)
 
   const createPiece = useCallback((id: number): ConfettiPiece => {
     const shapes: ConfettiPiece['shape'][] = ['square', 'circle', 'triangle', 'star']
     return {
       id,
       x: Math.random() * 100,
-      y: -10 - Math.random() * 20,
+      y: -10,
       rotation: Math.random() * 360,
       color: colors[Math.floor(Math.random() * colors.length)],
       size: 8 + Math.random() * 8,
@@ -58,11 +59,13 @@ export default function Confetti({
 
   useEffect(() => {
     if (prefersReducedMotion) {
-      if (isActive) {
+      if (isActive && !wasActiveRef.current) {
         onComplete?.()
       }
+      wasActiveRef.current = isActive
       return
     }
+    wasActiveRef.current = isActive
 
     if (!isActive) {
       const raf = requestAnimationFrame(() => setPieces([]))
@@ -196,14 +199,17 @@ interface ConfettiBurstProps {
 export function ConfettiBurst({ x, y, isActive, onComplete }: ConfettiBurstProps) {
   const [pieces, setPieces] = useState<ConfettiPiece[]>([])
   const prefersReducedMotion = usePrefersReducedMotion()
+  const wasActiveRef = useRef(false)
 
   useEffect(() => {
     if (prefersReducedMotion) {
-      if (isActive) {
+      if (isActive && !wasActiveRef.current) {
         onComplete?.()
       }
+      wasActiveRef.current = isActive
       return
     }
+    wasActiveRef.current = isActive
 
     if (!isActive) {
       const raf = requestAnimationFrame(() => setPieces([]))
@@ -234,8 +240,9 @@ export function ConfettiBurst({ x, y, isActive, onComplete }: ConfettiBurstProps
     })
 
     const animate = () => {
-      setPieces((prev) =>
-        prev
+      setPieces((prev) => {
+        if (prev.length === 0) return prev
+        return prev
           .map((piece) => ({
             ...piece,
             x: piece.x + piece.velocityX,
@@ -245,11 +252,9 @@ export function ConfettiBurst({ x, y, isActive, onComplete }: ConfettiBurstProps
             velocityX: piece.velocityX * 0.98,
           }))
           .filter((piece) => piece.y < window.innerHeight + 50)
-      )
+      })
 
-      if (pieces.length > 0) {
-        animationId = requestAnimationFrame(animate)
-      }
+      animationId = requestAnimationFrame(animate)
     }
 
     animationId = requestAnimationFrame(animate)
@@ -266,7 +271,7 @@ export function ConfettiBurst({ x, y, isActive, onComplete }: ConfettiBurstProps
       if (animationId) cancelAnimationFrame(animationId)
       clearTimeout(timeout)
     }
-  }, [isActive, x, y, onComplete, prefersReducedMotion, pieces.length])
+  }, [isActive, x, y, onComplete, prefersReducedMotion])
 
   if (prefersReducedMotion || pieces.length === 0) return null
 

--- a/components/effects/FallingSnow.tsx
+++ b/components/effects/FallingSnow.tsx
@@ -24,7 +24,10 @@ export function FallingSnow({ count = 50, active = true }: FallingSnowProps) {
   const prefersReducedMotion = usePrefersReducedMotion()
 
   useEffect(() => {
-    if (!active || prefersReducedMotion) return
+    if (!active || prefersReducedMotion) {
+      const raf = requestAnimationFrame(() => setSnowflakes([]))
+      return () => cancelAnimationFrame(raf)
+    }
 
     const createSingleSnowflake = (): Snowflake => ({
       id: Date.now() + Math.random() * 10000,

--- a/components/effects/Fireflies.tsx
+++ b/components/effects/Fireflies.tsx
@@ -34,9 +34,7 @@ export function Fireflies({ active, count = 25 }: FirefliesProps) {
   }, [])
 
   useEffect(() => {
-    if (prefersReducedMotion) return
-
-    if (!active) {
+    if (!active || prefersReducedMotion) {
       const raf = requestAnimationFrame(() => setFireflies([]))
       return () => cancelAnimationFrame(raf)
     }

--- a/components/effects/Fireflies.tsx
+++ b/components/effects/Fireflies.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
+import { usePrefersReducedMotion } from '@/lib/hooks/useMediaQuery'
 
 interface FirefliesProps {
   active: boolean
@@ -19,6 +20,7 @@ interface Firefly {
 
 export function Fireflies({ active, count = 25 }: FirefliesProps) {
   const [fireflies, setFireflies] = useState<Firefly[]>([])
+  const prefersReducedMotion = usePrefersReducedMotion()
 
   const createFirefly = useCallback((): Firefly => {
     return {
@@ -32,13 +34,16 @@ export function Fireflies({ active, count = 25 }: FirefliesProps) {
   }, [])
 
   useEffect(() => {
+    if (prefersReducedMotion) return
+
     if (!active) {
-      setFireflies([])
-      return
+      const raf = requestAnimationFrame(() => setFireflies([]))
+      return () => cancelAnimationFrame(raf)
     }
 
-    const initial = Array.from({ length: count }, createFirefly)
-    setFireflies(initial)
+    const initialRaf = requestAnimationFrame(() => {
+      setFireflies(Array.from({ length: count }, createFirefly))
+    })
 
     const interval = setInterval(() => {
       setFireflies(prev => {
@@ -49,8 +54,14 @@ export function Fireflies({ active, count = 25 }: FirefliesProps) {
       })
     }, 1000)
 
-    return () => clearInterval(interval)
-  }, [active, count, createFirefly])
+    return () => {
+      cancelAnimationFrame(initialRaf)
+      clearInterval(interval)
+    }
+  }, [active, count, createFirefly, prefersReducedMotion])
+
+  // reduced-motion 時は描画もループも停止
+  if (prefersReducedMotion) return null
 
   if (!active) return null
 

--- a/components/effects/Ghosts.tsx
+++ b/components/effects/Ghosts.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
+import { usePrefersReducedMotion } from '@/lib/hooks/useMediaQuery'
 
 interface GhostsProps {
   active: boolean
@@ -19,6 +20,7 @@ interface Ghost {
 
 export function Ghosts({ active, count = 5 }: GhostsProps) {
   const [ghosts, setGhosts] = useState<Ghost[]>([])
+  const prefersReducedMotion = usePrefersReducedMotion()
 
   const createGhost = useCallback((): Ghost => {
     return {
@@ -32,13 +34,16 @@ export function Ghosts({ active, count = 5 }: GhostsProps) {
   }, [])
 
   useEffect(() => {
+    if (prefersReducedMotion) return
+
     if (!active) {
-      setGhosts([])
-      return
+      const raf = requestAnimationFrame(() => setGhosts([]))
+      return () => cancelAnimationFrame(raf)
     }
 
-    const initial = Array.from({ length: count }, createGhost)
-    setGhosts(initial)
+    const initialRaf = requestAnimationFrame(() => {
+      setGhosts(Array.from({ length: count }, createGhost))
+    })
 
     const interval = setInterval(() => {
       setGhosts(prev => {
@@ -50,8 +55,14 @@ export function Ghosts({ active, count = 5 }: GhostsProps) {
       })
     }, 3000)
 
-    return () => clearInterval(interval)
-  }, [active, count, createGhost])
+    return () => {
+      cancelAnimationFrame(initialRaf)
+      clearInterval(interval)
+    }
+  }, [active, count, createGhost, prefersReducedMotion])
+
+  // reduced-motion 時は描画もループも停止
+  if (prefersReducedMotion) return null
 
   if (!active) return null
 

--- a/components/effects/Ghosts.tsx
+++ b/components/effects/Ghosts.tsx
@@ -34,9 +34,7 @@ export function Ghosts({ active, count = 5 }: GhostsProps) {
   }, [])
 
   useEffect(() => {
-    if (prefersReducedMotion) return
-
-    if (!active) {
+    if (!active || prefersReducedMotion) {
       const raf = requestAnimationFrame(() => setGhosts([]))
       return () => cancelAnimationFrame(raf)
     }

--- a/components/effects/Koinobori.tsx
+++ b/components/effects/Koinobori.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { useEffect, useState } from 'react'
 import { motion } from 'framer-motion'
 
 interface KoinoboriProps {
@@ -8,33 +7,23 @@ interface KoinoboriProps {
   count?: number
 }
 
+const KOI_COLORS = [
+  ['#000000', '#333333'],
+  ['#DC143C', '#FF4500'],
+  ['#1E90FF', '#00BFFF'],
+  ['#FF69B4', '#FFB6C1'],
+  ['#32CD32', '#7CFC00'],
+]
+
 export function Koinobori({ active, count = 3 }: KoinoboriProps) {
-  const [kois, setKois] = useState<{ id: number; x: number; colors: string[]; size: number }[]>([])
-
-  const KOI_COLORS = [
-    ['#000000', '#333333'],
-    ['#DC143C', '#FF4500'],
-    ['#1E90FF', '#00BFFF'],
-    ['#FF69B4', '#FFB6C1'],
-    ['#32CD32', '#7CFC00'],
-  ]
-
-  useEffect(() => {
-    if (!active) {
-      setKois([])
-      return
-    }
-
-    const newKois = Array.from({ length: Math.min(count, 5) }, (_, i) => ({
-      id: i,
-      x: 15 + i * 18,
-      colors: KOI_COLORS[i % KOI_COLORS.length],
-      size: i === 0 ? 1.2 : i === 1 ? 1 : 0.8,
-    }))
-    setKois(newKois)
-  }, [active, count])
-
   if (!active) return null
+
+  const kois = Array.from({ length: Math.min(count, 5) }, (_, i) => ({
+    id: i,
+    x: 15 + i * 18,
+    colors: KOI_COLORS[i % KOI_COLORS.length],
+    size: i === 0 ? 1.2 : i === 1 ? 1 : 0.8,
+  }))
 
   return (
     <div className="fixed top-0 left-0 right-0 pointer-events-none z-35 h-64">

--- a/components/effects/ParticleSystem.tsx
+++ b/components/effects/ParticleSystem.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useCallback } from 'react'
+import { usePrefersReducedMotion } from '@/lib/hooks/useMediaQuery'
 
 interface Particle {
   x: number
@@ -75,6 +76,7 @@ export default function ParticleSystem({
   const particlesRef = useRef<Particle[]>([])
   const mouseRef = useRef({ x: 0, y: 0 })
   const animationRef = useRef<number | null>(null)
+  const prefersReducedMotion = usePrefersReducedMotion()
 
   const config = particleConfigs[type]
 
@@ -107,6 +109,8 @@ export default function ParticleSystem({
   }
 
   useEffect(() => {
+    if (prefersReducedMotion) return
+
     const canvas = canvasRef.current
     if (!canvas) return
 
@@ -199,7 +203,10 @@ export default function ParticleSystem({
         cancelAnimationFrame(animationRef.current)
       }
     }
-  }, [isActive, type, initialX, initialY, followMouse, particleCount, createParticle, config.gravity])
+  }, [isActive, type, initialX, initialY, followMouse, particleCount, createParticle, config.gravity, prefersReducedMotion])
+
+  // reduced-motion 時は描画もループも停止
+  if (prefersReducedMotion) return null
 
   return (
     <canvas

--- a/components/effects/Sparkles.tsx
+++ b/components/effects/Sparkles.tsx
@@ -37,7 +37,7 @@ export function Sparkles({ active, count = 30, colors = ['#FFD700', '#FFFFFF', '
   }, [colors])
 
   useEffect(() => {
-    if (!active) {
+    if (!active || prefersReducedMotion) {
       const raf = requestAnimationFrame(() => setSparkles([]))
       return () => cancelAnimationFrame(raf)
     }

--- a/components/effects/Sparkles.tsx
+++ b/components/effects/Sparkles.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
+import { usePrefersReducedMotion } from '@/lib/hooks/useMediaQuery'
 
 interface SparklesProps {
   active: boolean
@@ -21,6 +22,7 @@ interface Sparkle {
 
 export function Sparkles({ active, count = 30, colors = ['#FFD700', '#FFFFFF', '#FFF8DC'] }: SparklesProps) {
   const [sparkles, setSparkles] = useState<Sparkle[]>([])
+  const prefersReducedMotion = usePrefersReducedMotion()
 
   const createSparkle = useCallback((): Sparkle => {
     return {
@@ -36,12 +38,13 @@ export function Sparkles({ active, count = 30, colors = ['#FFD700', '#FFFFFF', '
 
   useEffect(() => {
     if (!active) {
-      setSparkles([])
-      return
+      const raf = requestAnimationFrame(() => setSparkles([]))
+      return () => cancelAnimationFrame(raf)
     }
 
-    const initial = Array.from({ length: count }, createSparkle)
-    setSparkles(initial)
+    const initialRaf = requestAnimationFrame(() => {
+      setSparkles(Array.from({ length: count }, createSparkle))
+    })
 
     const interval = setInterval(() => {
       setSparkles(prev => {
@@ -52,15 +55,21 @@ export function Sparkles({ active, count = 30, colors = ['#FFD700', '#FFFFFF', '
       })
     }, 500)
 
-    return () => clearInterval(interval)
-  }, [active, count, createSparkle])
+    return () => {
+      cancelAnimationFrame(initialRaf)
+      clearInterval(interval)
+    }
+  }, [active, count, createSparkle, prefersReducedMotion])
+
+  // reduced-motion 時は描画もループも停止
+  if (prefersReducedMotion) return null
 
   if (!active) return null
 
   return (
     <div className="fixed inset-0 pointer-events-none z-30 overflow-hidden">
       <AnimatePresence>
-        {sparkles.map(sparkle => (
+        {sparkles.map((sparkle, i) => (
           <motion.div
             key={sparkle.id}
             initial={{ opacity: 0, scale: 0 }}
@@ -74,7 +83,7 @@ export function Sparkles({ active, count = 30, colors = ['#FFD700', '#FFFFFF', '
               duration: sparkle.duration,
               delay: sparkle.delay,
               repeat: Infinity,
-              repeatDelay: Math.random() * 2,
+              repeatDelay: ((i * 37) % 100) / 50,
             }}
             className="absolute"
             style={{

--- a/components/effects/VideoBackground.tsx
+++ b/components/effects/VideoBackground.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useSyncExternalStore } from 'react'
+import { usePrefersReducedMotion } from '@/lib/hooks/useMediaQuery'
 
 interface VideoBackgroundProps {
   videoUrl?: string
@@ -10,6 +11,10 @@ interface VideoBackgroundProps {
   opacity?: number
   syncToServerTime?: boolean
   videoDuration?: number
+}
+
+function computeStartSeconds(videoDuration: number): number {
+  return Math.floor((Date.now() / 1000) % videoDuration)
 }
 
 export function VideoBackground({
@@ -25,19 +30,25 @@ export function VideoBackground({
   const [currentSrc, setCurrentSrc] = useState(videoUrl)
   const [hasError, setHasError] = useState(false)
   const [videoLoaded, setVideoLoaded] = useState(false)
-  const [isMounted, setIsMounted] = useState(false)
+  const [prevVideoUrl, setPrevVideoUrl] = useState(videoUrl)
+  const [startSeconds] = useState(() =>
+    typeof window !== 'undefined' && syncToServerTime && videoDuration > 0
+      ? computeStartSeconds(videoDuration)
+      : null
+  )
+  const prefersReducedMotion = usePrefersReducedMotion()
+  const mounted = useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false
+  )
 
-  useEffect(() => {
-    setIsMounted(true)
-  }, [])
-
-  useEffect(() => {
-    if (videoUrl) {
-      setCurrentSrc(videoUrl)
-      setHasError(false)
-      setVideoLoaded(false)
-    }
-  }, [videoUrl])
+  if (videoUrl !== prevVideoUrl) {
+    setPrevVideoUrl(videoUrl)
+    setCurrentSrc(videoUrl)
+    setHasError(false)
+    setVideoLoaded(false)
+  }
 
   useEffect(() => {
     const video = videoRef.current
@@ -94,7 +105,10 @@ export function VideoBackground({
 
   if (!active) return null
 
-  if (!isMounted) {
+  // reduced-motion 時は背景動画/YouTube を描画しない（親のグラデーションが代替）
+  if (prefersReducedMotion) return null
+
+  if (!mounted) {
     return (
       <div
         style={{
@@ -114,9 +128,7 @@ export function VideoBackground({
     const origin = window.location.origin
 
     let startParam = ''
-    if (syncToServerTime && videoDuration > 0) {
-      const now = Date.now() / 1000
-      const startSeconds = Math.floor(now % videoDuration)
+    if (startSeconds !== null) {
       startParam = `&start=${startSeconds}`
     }
 

--- a/components/effects/VideoBackground.tsx
+++ b/components/effects/VideoBackground.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, useEffect, useSyncExternalStore } from 'react'
+import { useState, useRef, useEffect, useMemo, useSyncExternalStore } from 'react'
 import { usePrefersReducedMotion } from '@/lib/hooks/useMediaQuery'
 
 interface VideoBackgroundProps {
@@ -30,12 +30,6 @@ export function VideoBackground({
   const [currentSrc, setCurrentSrc] = useState(videoUrl)
   const [hasError, setHasError] = useState(false)
   const [videoLoaded, setVideoLoaded] = useState(false)
-  const [prevVideoUrl, setPrevVideoUrl] = useState(videoUrl)
-  const [startSeconds] = useState(() =>
-    typeof window !== 'undefined' && syncToServerTime && videoDuration > 0
-      ? computeStartSeconds(videoDuration)
-      : null
-  )
   const prefersReducedMotion = usePrefersReducedMotion()
   const mounted = useSyncExternalStore(
     () => () => {},
@@ -43,12 +37,21 @@ export function VideoBackground({
     () => false
   )
 
-  if (videoUrl !== prevVideoUrl) {
-    setPrevVideoUrl(videoUrl)
-    setCurrentSrc(videoUrl)
-    setHasError(false)
-    setVideoLoaded(false)
-  }
+  // props の videoUrl 変更を useEffect で安全に同期
+  useEffect(() => {
+    const raf = requestAnimationFrame(() => {
+      setCurrentSrc(videoUrl)
+      setHasError(false)
+      setVideoLoaded(false)
+    })
+    return () => cancelAnimationFrame(raf)
+  }, [videoUrl])
+
+  // YouTube の開始位置を props の最新状態から導出
+  const startSeconds = useMemo(() => {
+    if (!mounted || !syncToServerTime || !videoDuration || videoDuration <= 0) return null
+    return computeStartSeconds(videoDuration)
+  }, [mounted, syncToServerTime, videoDuration])
 
   useEffect(() => {
     const video = videoRef.current

--- a/components/features/Balloons.tsx
+++ b/components/features/Balloons.tsx
@@ -25,22 +25,26 @@ export function Balloons({ active, count = 15 }: BalloonsProps) {
     if (active) {
       const colors = ['#ff6b6b', '#4ecdc4', '#45b7d1', '#f9ca24', '#6c5ce7', '#fd79a8']
 
-      const newBalloons = Array.from({ length: count }, (_, i) => ({
-        id: i,
-        x: Math.random() * 90 + 5,
-        color: colors[Math.floor(Math.random() * colors.length)],
-        delay: Math.random() * 2,
-        duration: 4 + Math.random() * 3,
-        size: 40 + Math.random() * 30,
-      }))
-
-      setBalloons(newBalloons)
+      const spawnRaf = requestAnimationFrame(() => {
+        const newBalloons = Array.from({ length: count }, (_, i) => ({
+          id: i,
+          x: Math.random() * 90 + 5,
+          color: colors[Math.floor(Math.random() * colors.length)],
+          delay: Math.random() * 2,
+          duration: 4 + Math.random() * 3,
+          size: 40 + Math.random() * 30,
+        }))
+        setBalloons(newBalloons)
+      })
 
       const timer = setTimeout(() => {
         setBalloons([])
       }, 8000)
 
-      return () => clearTimeout(timer)
+      return () => {
+        cancelAnimationFrame(spawnRaf)
+        clearTimeout(timer)
+      }
     }
   }, [active, count])
 
@@ -57,8 +61,8 @@ export function Balloons({ active, count = 15 }: BalloonsProps) {
             }}
             animate={{
               y: '-20vh',
-              x: `${balloon.x + (Math.random() - 0.5) * 20}vw`,
-              rotate: (Math.random() - 0.5) * 30,
+              x: `${balloon.x + (((balloon.id * 37) % 100) / 100 - 0.5) * 20}vw`,
+              rotate: (((balloon.id * 53) % 100) / 100 - 0.5) * 30,
             }}
             exit={{ opacity: 0 }}
             transition={{

--- a/components/features/Balloons.tsx
+++ b/components/features/Balloons.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
+import { usePrefersReducedMotion } from '@/lib/hooks/useMediaQuery'
 
 interface BalloonsProps {
   active: boolean
@@ -20,33 +21,41 @@ interface Balloon {
 // 風船コンポーネント
 export function Balloons({ active, count = 15 }: BalloonsProps) {
   const [balloons, setBalloons] = useState<Balloon[]>([])
+  const prefersReducedMotion = usePrefersReducedMotion()
 
   useEffect(() => {
-    if (active) {
-      const colors = ['#ff6b6b', '#4ecdc4', '#45b7d1', '#f9ca24', '#6c5ce7', '#fd79a8']
+    if (!active || prefersReducedMotion) {
+      const raf = requestAnimationFrame(() => setBalloons([]))
+      return () => cancelAnimationFrame(raf)
+    }
 
-      const spawnRaf = requestAnimationFrame(() => {
-        const newBalloons = Array.from({ length: count }, (_, i) => ({
-          id: i,
-          x: Math.random() * 90 + 5,
-          color: colors[Math.floor(Math.random() * colors.length)],
-          delay: Math.random() * 2,
-          duration: 4 + Math.random() * 3,
-          size: 40 + Math.random() * 30,
-        }))
-        setBalloons(newBalloons)
-      })
+    const colors = ['#ff6b6b', '#4ecdc4', '#45b7d1', '#f9ca24', '#6c5ce7', '#fd79a8']
+    let timer: NodeJS.Timeout | null = null
 
-      const timer = setTimeout(() => {
+    const spawnRaf = requestAnimationFrame(() => {
+      const newBalloons = Array.from({ length: count }, (_, i) => ({
+        id: i,
+        x: Math.random() * 90 + 5,
+        color: colors[Math.floor(Math.random() * colors.length)],
+        delay: Math.random() * 2,
+        duration: 4 + Math.random() * 3,
+        size: 40 + Math.random() * 30,
+      }))
+      setBalloons(newBalloons)
+
+      // RAF 実行後にタイマーを開始し、遅延生成との順序逆転を防ぐ
+      timer = setTimeout(() => {
         setBalloons([])
       }, 8000)
+    })
 
-      return () => {
-        cancelAnimationFrame(spawnRaf)
-        clearTimeout(timer)
-      }
+    return () => {
+      cancelAnimationFrame(spawnRaf)
+      if (timer) clearTimeout(timer)
     }
-  }, [active, count])
+  }, [active, count, prefersReducedMotion])
+
+  if (!active || prefersReducedMotion) return null
 
   return (
     <div className="fixed inset-0 pointer-events-none z-40 overflow-hidden">

--- a/components/features/Candle.tsx
+++ b/components/features/Candle.tsx
@@ -50,7 +50,7 @@ export function Candle({ isBlown, delay = 0, onBlown }: CandleProps) {
                   scale: [0, 1, 2],
                   opacity: [0.7, 0.4, 0],
                   y: [0, -20, -40],
-                  x: [(Math.random() - 0.5) * 10, (Math.random() - 0.5) * 20],
+                  x: [(((i * 37) % 100) / 100 - 0.5) * 10, (((i * 61) % 100) / 100 - 0.5) * 20],
                 }}
                 transition={{
                   duration: 2,

--- a/components/features/Confetti.tsx
+++ b/components/features/Confetti.tsx
@@ -37,24 +37,28 @@ export function Confetti({ active, count = 50 }: ConfettiProps) {
         '#00bbf9',
       ]
 
-      const newPieces = Array.from({ length: count }, (_, i) => ({
-        id: i,
-        x: Math.random() * 100,
-        color: colors[Math.floor(Math.random() * colors.length)],
-        delay: Math.random() * 0.5,
-        duration: 2 + Math.random() * 2,
-        rotation: Math.random() * 720,
-        size: 8 + Math.random() * 8,
-      }))
-
-      setPieces(newPieces)
+      const spawnRaf = requestAnimationFrame(() => {
+        const newPieces = Array.from({ length: count }, (_, i) => ({
+          id: i,
+          x: Math.random() * 100,
+          color: colors[Math.floor(Math.random() * colors.length)],
+          delay: Math.random() * 0.5,
+          duration: 2 + Math.random() * 2,
+          rotation: Math.random() * 720,
+          size: 8 + Math.random() * 8,
+        }))
+        setPieces(newPieces)
+      })
 
       // 一定時間後にクリア
       const timer = setTimeout(() => {
         setPieces([])
       }, 5000)
 
-      return () => clearTimeout(timer)
+      return () => {
+        cancelAnimationFrame(spawnRaf)
+        clearTimeout(timer)
+      }
     }
   }, [active, count])
 
@@ -86,7 +90,7 @@ export function Confetti({ active, count = 50 }: ConfettiProps) {
               width: piece.size,
               height: piece.size,
               backgroundColor: piece.color,
-              borderRadius: Math.random() > 0.5 ? '50%' : '0',
+              borderRadius: piece.id % 2 === 0 ? '50%' : '0',
             }}
           />
         ))}

--- a/components/features/CountdownTimer.tsx
+++ b/components/features/CountdownTimer.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useSyncExternalStore } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { getTimeUntilBirthday } from '@/lib/utils/birthday'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
@@ -12,14 +12,22 @@ interface CountdownTimerProps {
 
 // ポラロイド風ミニフォトカードによるカウントダウンタイマーコンポーネント（モバイルコンパクト最適化版）
 export function CountdownTimer({ targetDate, onComplete }: CountdownTimerProps) {
-  const [mounted, setMounted] = useState(false)
-  const [timeLeft, setTimeLeft] = useState({ days: 0, hours: 0, minutes: 0, seconds: 0, isExpired: false })
+  const mounted = useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false
+  )
+  // クライアント側でのみ時間計算を実行（SSR ではゼロ値）
+  const [timeLeft, setTimeLeft] = useState(() =>
+    typeof window === 'undefined'
+      ? { days: 0, hours: 0, minutes: 0, seconds: 0, isExpired: false }
+      : getTimeUntilBirthday(targetDate)
+  )
   const { t } = useLanguage()
 
-  // クライアント側でのみ時間計算を実行
   useEffect(() => {
-    setMounted(true)
-    setTimeLeft(getTimeUntilBirthday(targetDate))
+    const raf = requestAnimationFrame(() => setTimeLeft(getTimeUntilBirthday(targetDate)))
+    return () => cancelAnimationFrame(raf)
   }, [targetDate])
 
   useEffect(() => {

--- a/components/features/DailyOmikuji.tsx
+++ b/components/features/DailyOmikuji.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useMemo } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import dynamic from 'next/dynamic'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
@@ -39,32 +39,28 @@ const OmikujiCylinder3D = dynamic(
 export function DailyOmikuji({ onClose }: { onClose?: () => void }) {
   const { t, language } = useLanguage()
   const [isShaking, setIsShaking] = useState(false)
-  const [result, setResult] = useState<OmikujiFortune | null>(null)
-  const [activeCategory, setActiveCategory] = useState<'all' | 'bond' | 'health' | 'wish' | 'blessing'>('all')
-
   // ユーザーのローカル深夜0時に切り替わるキー
   const todayKey = useMemo(() => {
     const now = new Date()
     return `omikuji_${now.getFullYear()}_${String(now.getMonth() + 1).padStart(2, '0')}_${String(now.getDate()).padStart(2, '0')}`
   }, [])
-
-  // 本日すでに引いた結果があればロード（旧スキーマのキャッシュを自動補正・完全復元）
-  useEffect(() => {
+  // 本日すでに引いた結果があれば復元（旧スキーマのキャッシュも自動補正）
+  const [result, setResult] = useState<OmikujiFortune | null>(() => {
+    if (typeof window === 'undefined') return null
     try {
-      const saved = localStorage.getItem(todayKey)
-      if (saved) {
-        const parsed = JSON.parse(saved)
-        const matched =
-          OMIKUJI_DATA.find((f) => f.id === parsed?.id) ||
-          OMIKUJI_DATA.find((f) => f.rank === parsed?.rank) ||
-          OMIKUJI_DATA[0]
-        setResult(matched)
-        localStorage.setItem(todayKey, JSON.stringify(matched))
-      }
+      const saved = window.localStorage.getItem(todayKey)
+      if (!saved) return null
+      const parsed = JSON.parse(saved) as { id?: number; rank?: string }
+      return (
+        OMIKUJI_DATA.find((f) => f.id === parsed?.id) ||
+        OMIKUJI_DATA.find((f) => f.rank === parsed?.rank) ||
+        null
+      )
     } catch {
-      // localStorage 利用不可時は無視
+      return null
     }
-  }, [todayKey])
+  })
+  const [activeCategory, setActiveCategory] = useState<'all' | 'bond' | 'health' | 'wish' | 'blessing'>('all')
 
   // おみくじを引くアニメーション処理
   const handleDraw = () => {

--- a/components/features/MediaUploader.tsx
+++ b/components/features/MediaUploader.tsx
@@ -55,7 +55,7 @@ export function MediaUploader({ onUploadComplete }: MediaUploaderProps) {
         onUploadComplete()
       }
     },
-    [uploadFile, onUploadComplete]
+    [uploadFile, onUploadComplete, t]
   )
 
   const handleDragOver = useCallback((e: React.DragEvent) => {

--- a/components/features/MediaViewer.tsx
+++ b/components/features/MediaViewer.tsx
@@ -109,7 +109,30 @@ export function MediaViewer({
     if (!mounted) return
     lastFocusedRef.current = document.activeElement
     viewerRef.current?.focus()
+
+    // 背後要素を inert / aria-hidden 化してアクセシビリティ上の脱出を防止
+    const mainEl = document.querySelector('main')
+    const originalInert = mainEl?.getAttribute('inert')
+    const originalAriaHidden = mainEl?.getAttribute('aria-hidden')
+
+    if (mainEl) {
+      mainEl.setAttribute('inert', '')
+      mainEl.setAttribute('aria-hidden', 'true')
+    }
+
     return () => {
+      if (mainEl) {
+        if (originalInert !== null && originalInert !== undefined) {
+          mainEl.setAttribute('inert', originalInert)
+        } else {
+          mainEl.removeAttribute('inert')
+        }
+        if (originalAriaHidden !== null && originalAriaHidden !== undefined) {
+          mainEl.setAttribute('aria-hidden', originalAriaHidden)
+        } else {
+          mainEl.removeAttribute('aria-hidden')
+        }
+      }
       if (lastFocusedRef.current instanceof HTMLElement) {
         lastFocusedRef.current.focus()
       }

--- a/components/features/MediaViewer.tsx
+++ b/components/features/MediaViewer.tsx
@@ -149,6 +149,7 @@ export function MediaViewer({
         aria-modal="true"
         aria-label={media.file_name}
         tabIndex={-1}
+        className="focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#D4B08C] focus:outline-none"
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
@@ -164,7 +165,6 @@ export function MediaViewer({
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          outline: 'none',
         }}
       >
         {/* 上部コントロール */}

--- a/components/features/MediaViewer.tsx
+++ b/components/features/MediaViewer.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useCallback, useState } from 'react'
+import { useEffect, useCallback, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import type { MediaFile } from '@/types'
@@ -101,9 +101,28 @@ export function MediaViewer({
     onToggleSlideshow?.()
   }
 
+  const viewerRef = useRef<HTMLDivElement>(null)
+  const lastFocusedRef = useRef<Element | null>(null)
+
+  // ダイアログとしてのフォーカス lifecycle（開いたら奪い、閉じたら返す）
+  useEffect(() => {
+    lastFocusedRef.current = document.activeElement
+    viewerRef.current?.focus()
+    return () => {
+      if (lastFocusedRef.current instanceof HTMLElement) {
+        lastFocusedRef.current.focus()
+      }
+    }
+  }, [])
+
   const viewerContent = (
     <AnimatePresence>
       <motion.div
+        ref={viewerRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={media.file_name}
+        tabIndex={-1}
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
@@ -119,6 +138,7 @@ export function MediaViewer({
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
+          outline: 'none',
         }}
       >
         {/* 上部コントロール */}

--- a/components/features/MediaViewer.tsx
+++ b/components/features/MediaViewer.tsx
@@ -122,13 +122,13 @@ export function MediaViewer({
     const handleTab = (e: KeyboardEvent) => {
       if (e.key !== 'Tab' || !viewerRef.current) return
       const focusableElements = viewerRef.current.querySelectorAll(
-        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), video[controls], [tabindex]:not([tabindex="-1"])'
       )
       if (focusableElements.length === 0) return
       const firstElement = focusableElements[0] as HTMLElement
       const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement
 
-      if (e.shiftKey && document.activeElement === firstElement) {
+      if (e.shiftKey && (document.activeElement === firstElement || document.activeElement === viewerRef.current)) {
         e.preventDefault()
         lastElement?.focus()
       } else if (!e.shiftKey && document.activeElement === lastElement) {

--- a/components/features/MediaViewer.tsx
+++ b/components/features/MediaViewer.tsx
@@ -110,27 +110,43 @@ export function MediaViewer({
     lastFocusedRef.current = document.activeElement
     viewerRef.current?.focus()
 
-    // 背後要素を inert / aria-hidden 化してアクセシビリティ上の脱出を防止
-    const mainEl = document.querySelector('main')
-    const originalInert = mainEl?.getAttribute('inert')
-    const originalAriaHidden = mainEl?.getAttribute('aria-hidden')
+    // viewerRef.current 以外のすべての body 直下要素（背景・親モーダル・ポータル）を inert / aria-hidden 化
+    const viewerElement = viewerRef.current
+    const restoredElements: Array<{
+      element: HTMLElement
+      originalInert: string | null
+      originalAriaHidden: string | null
+    }> = []
 
-    if (mainEl) {
-      mainEl.setAttribute('inert', '')
-      mainEl.setAttribute('aria-hidden', 'true')
+    const bodyChildren = Array.from(document.body.children)
+    for (const child of bodyChildren) {
+      if (
+        child instanceof HTMLElement &&
+        child !== viewerElement &&
+        !child.contains(viewerElement) &&
+        !['SCRIPT', 'STYLE', 'LINK'].includes(child.tagName)
+      ) {
+        restoredElements.push({
+          element: child,
+          originalInert: child.getAttribute('inert'),
+          originalAriaHidden: child.getAttribute('aria-hidden'),
+        })
+        child.setAttribute('inert', '')
+        child.setAttribute('aria-hidden', 'true')
+      }
     }
 
     return () => {
-      if (mainEl) {
-        if (originalInert !== null && originalInert !== undefined) {
-          mainEl.setAttribute('inert', originalInert)
+      for (const { element, originalInert, originalAriaHidden } of restoredElements) {
+        if (originalInert !== null) {
+          element.setAttribute('inert', originalInert)
         } else {
-          mainEl.removeAttribute('inert')
+          element.removeAttribute('inert')
         }
-        if (originalAriaHidden !== null && originalAriaHidden !== undefined) {
-          mainEl.setAttribute('aria-hidden', originalAriaHidden)
+        if (originalAriaHidden !== null) {
+          element.setAttribute('aria-hidden', originalAriaHidden)
         } else {
-          mainEl.removeAttribute('aria-hidden')
+          element.removeAttribute('aria-hidden')
         }
       }
       if (lastFocusedRef.current instanceof HTMLElement) {

--- a/components/features/MediaViewer.tsx
+++ b/components/features/MediaViewer.tsx
@@ -104,8 +104,9 @@ export function MediaViewer({
   const viewerRef = useRef<HTMLDivElement>(null)
   const lastFocusedRef = useRef<Element | null>(null)
 
-  // ダイアログとしてのフォーカス lifecycle（開いたら奪い、閉じたら返す）
+  // ダイアログとしてのフォーカス lifecycle（portal mount 後にフォーカスを奪い、閉じたら返す）
   useEffect(() => {
+    if (!mounted) return
     lastFocusedRef.current = document.activeElement
     viewerRef.current?.focus()
     return () => {
@@ -113,7 +114,32 @@ export function MediaViewer({
         lastFocusedRef.current.focus()
       }
     }
-  }, [])
+  }, [mounted])
+
+  // Tab キーによるダイアログ内のフォーカストラップ
+  useEffect(() => {
+    if (!mounted) return
+    const handleTab = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab' || !viewerRef.current) return
+      const focusableElements = viewerRef.current.querySelectorAll(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      )
+      if (focusableElements.length === 0) return
+      const firstElement = focusableElements[0] as HTMLElement
+      const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement
+
+      if (e.shiftKey && document.activeElement === firstElement) {
+        e.preventDefault()
+        lastElement?.focus()
+      } else if (!e.shiftKey && document.activeElement === lastElement) {
+        e.preventDefault()
+        firstElement?.focus()
+      }
+    }
+
+    document.addEventListener('keydown', handleTab)
+    return () => document.removeEventListener('keydown', handleTab)
+  }, [mounted])
 
   const viewerContent = (
     <AnimatePresence>

--- a/components/features/MediaViewer.tsx
+++ b/components/features/MediaViewer.tsx
@@ -18,6 +18,36 @@ interface MediaViewerProps {
   onToggleSlideshow?: () => void
 }
 
+function findVisibleFallback(): HTMLElement | null {
+  if (typeof document === 'undefined') return null
+  const candidates = document.querySelectorAll<HTMLElement>(
+    'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+  )
+  for (const el of candidates) {
+    if (
+      !el.isConnected ||
+      el.hasAttribute('inert') ||
+      el.closest('[inert]') ||
+      el.getAttribute('aria-hidden') === 'true' ||
+      el.closest('[aria-hidden="true"]')
+    ) {
+      continue
+    }
+    const style = window.getComputedStyle(el)
+    if (style.display === 'none' || style.visibility === 'hidden') {
+      continue
+    }
+    const rect = el.getBoundingClientRect()
+    if (rect.width > 0 && rect.height > 0) {
+      return el
+    }
+    if (el.offsetWidth > 0 || el.offsetHeight > 0) {
+      return el
+    }
+  }
+  return null
+}
+
 export function MediaViewer({ 
   media, 
   allMedia, 
@@ -149,8 +179,12 @@ export function MediaViewer({
           element.removeAttribute('aria-hidden')
         }
       }
-      if (lastFocusedRef.current instanceof HTMLElement) {
-        lastFocusedRef.current.focus()
+      const saved = lastFocusedRef.current
+      if (saved instanceof HTMLElement && saved.isConnected) {
+        saved.focus()
+      } else {
+        const fallback = findVisibleFallback()
+        fallback?.focus()
       }
     }
   }, [mounted])

--- a/components/features/MediaViewer.tsx
+++ b/components/features/MediaViewer.tsx
@@ -140,34 +140,47 @@ export function MediaViewer({
     lastFocusedRef.current = document.activeElement
     viewerRef.current?.focus()
 
-    // viewerRef.current 以外のすべての body 直下要素（背景・親モーダル・ポータル）を inert / aria-hidden 化
+    // viewerRef.current 以外のすべての body 直下要素（背景・親モーダル・動的ポータル）を inert / aria-hidden 化
     const viewerElement = viewerRef.current
-    const restoredElements: Array<{
-      element: HTMLElement
-      originalInert: string | null
-      originalAriaHidden: string | null
-    }> = []
+    const modifiedElements = new Map<HTMLElement, { originalInert: string | null; originalAriaHidden: string | null }>()
 
-    const bodyChildren = Array.from(document.body.children)
-    for (const child of bodyChildren) {
+    const isolateNode = (node: Node) => {
       if (
-        child instanceof HTMLElement &&
-        child !== viewerElement &&
-        !child.contains(viewerElement) &&
-        !['SCRIPT', 'STYLE', 'LINK'].includes(child.tagName)
+        node instanceof HTMLElement &&
+        node !== viewerElement &&
+        !node.contains(viewerElement) &&
+        !['SCRIPT', 'STYLE', 'LINK'].includes(node.tagName)
       ) {
-        restoredElements.push({
-          element: child,
-          originalInert: child.getAttribute('inert'),
-          originalAriaHidden: child.getAttribute('aria-hidden'),
-        })
-        child.setAttribute('inert', '')
-        child.setAttribute('aria-hidden', 'true')
+        if (!modifiedElements.has(node)) {
+          modifiedElements.set(node, {
+            originalInert: node.getAttribute('inert'),
+            originalAriaHidden: node.getAttribute('aria-hidden'),
+          })
+          node.setAttribute('inert', '')
+          node.setAttribute('aria-hidden', 'true')
+        }
       }
     }
 
+    // 初期 body 直下要素を隔離
+    const bodyChildren = Array.from(document.body.children)
+    for (const child of bodyChildren) {
+      isolateNode(child)
+    }
+
+    // viewer マウント後に追加されたポータル／兄弟要素も動的に隔離
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        for (const addedNode of Array.from(mutation.addedNodes)) {
+          isolateNode(addedNode)
+        }
+      }
+    })
+    observer.observe(document.body, { childList: true })
+
     return () => {
-      for (const { element, originalInert, originalAriaHidden } of restoredElements) {
+      observer.disconnect()
+      for (const [element, { originalInert, originalAriaHidden }] of modifiedElements) {
         if (originalInert !== null) {
           element.setAttribute('inert', originalInert)
         } else {

--- a/components/features/PhotoCard.tsx
+++ b/components/features/PhotoCard.tsx
@@ -16,6 +16,8 @@ export function PhotoCard({ media, onClick }: PhotoCardProps) {
 
   const isVideo = media.file_type === 'video'
 
+  const handleClick = () => onClick?.()
+
   return (
     <motion.div
       initial={{ opacity: 0, scale: 0.9 }}
@@ -24,7 +26,18 @@ export function PhotoCard({ media, onClick }: PhotoCardProps) {
       transition={{ duration: 0.3 }}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
-      onClick={onClick}
+      onClick={handleClick}
+      role="button"
+      tabIndex={0}
+      aria-label={media.file_name}
+      onFocus={() => setIsHovered(true)}
+      onBlur={() => setIsHovered(false)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          handleClick()
+        }
+      }}
       className="photo-card"
       style={{
         position: 'relative',

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useCallback, useRef, useState } from 'react'
+import { useEffect, useCallback, useRef, useState, useSyncExternalStore } from 'react'
 import { createPortal } from 'react-dom'
 import { Icon } from './Icon'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
@@ -45,9 +45,16 @@ export default function Modal({
 }: ModalProps) {
   const { t } = useLanguage()
   const [isAnimating, setIsAnimating] = useState(false)
-  const [shouldRender, setShouldRender] = useState(false)
+  const [shouldRender, setShouldRender] = useState(isOpen)
   const modalRef = useRef<HTMLDivElement>(null)
   const previousActiveElement = useRef<HTMLElement | null>(null)
+  const closeTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const focusTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const mounted = useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false
+  )
 
   // Escape キー押下時のクローズ処理
   const handleEscape = useCallback(
@@ -81,6 +88,10 @@ export default function Modal({
   // アニメーションとライフサイクル管理
   useEffect(() => {
     if (isOpen) {
+      if (closeTimeoutRef.current) {
+        clearTimeout(closeTimeoutRef.current)
+        closeTimeoutRef.current = null
+      }
       previousActiveElement.current = document.activeElement as HTMLElement
       requestAnimationFrame(() => {
         setShouldRender(true)
@@ -91,17 +102,21 @@ export default function Modal({
       document.addEventListener('keydown', handleTab)
 
       // 最初のフォーカス可能要素へフォーカス
-      setTimeout(() => {
+      focusTimeoutRef.current = setTimeout(() => {
         const firstFocusable = modalRef.current?.querySelector(
           'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
         ) as HTMLElement
         firstFocusable?.focus()
       }, 100)
     } else {
+      if (focusTimeoutRef.current) {
+        clearTimeout(focusTimeoutRef.current)
+        focusTimeoutRef.current = null
+      }
       requestAnimationFrame(() => {
         setIsAnimating(false)
       })
-      setTimeout(() => {
+      closeTimeoutRef.current = setTimeout(() => {
         setShouldRender(false)
         document.body.style.overflow = ''
         previousActiveElement.current?.focus()
@@ -115,6 +130,7 @@ export default function Modal({
     }
   }, [isOpen, handleEscape, handleTab])
 
+  if (!mounted) return null
   if (!shouldRender && !isOpen) return null
 
   const modalContent = (
@@ -261,11 +277,7 @@ export default function Modal({
   )
 
   // モーダルを document.body にポータルとして描画
-  if (typeof window !== 'undefined') {
-    return createPortal(modalContent, document.body)
-  }
-
-  return modalContent
+  return createPortal(modalContent, document.body)
 }
 
 // 確認用モーダルコンポーネント

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -124,6 +124,14 @@ export default function Modal({
     }
 
     return () => {
+      if (closeTimeoutRef.current) {
+        clearTimeout(closeTimeoutRef.current)
+        closeTimeoutRef.current = null
+      }
+      if (focusTimeoutRef.current) {
+        clearTimeout(focusTimeoutRef.current)
+        focusTimeoutRef.current = null
+      }
       document.removeEventListener('keydown', handleEscape)
       document.removeEventListener('keydown', handleTab)
       document.body.style.overflow = ''

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -82,8 +82,8 @@ export default function Modal({
   useEffect(() => {
     if (isOpen) {
       previousActiveElement.current = document.activeElement as HTMLElement
-      setShouldRender(true)
       requestAnimationFrame(() => {
+        setShouldRender(true)
         setIsAnimating(true)
       })
       document.body.style.overflow = 'hidden'
@@ -98,7 +98,9 @@ export default function Modal({
         firstFocusable?.focus()
       }, 100)
     } else {
-      setIsAnimating(false)
+      requestAnimationFrame(() => {
+        setIsAnimating(false)
+      })
       setTimeout(() => {
         setShouldRender(false)
         document.body.style.overflow = ''
@@ -113,7 +115,7 @@ export default function Modal({
     }
   }, [isOpen, handleEscape, handleTab])
 
-  if (!shouldRender) return null
+  if (!shouldRender && !isOpen) return null
 
   const modalContent = (
     <div

--- a/components/ui/Select.tsx
+++ b/components/ui/Select.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { forwardRef, SelectHTMLAttributes } from 'react'
+import { forwardRef, SelectHTMLAttributes, useId } from 'react'
 import { Icon } from '@/components/ui/Icon'
 
 interface SelectOption {
@@ -17,7 +17,8 @@ interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
 
 const Select = forwardRef<HTMLSelectElement, SelectProps>(
   ({ label, error, options, placeholder, className = '', id, ...props }, ref) => {
-    const selectId = id || `select-${Math.random().toString(36).substr(2, 9)}`
+    const autoId = useId()
+    const selectId = id || autoId
 
     return (
       <div className="w-full">

--- a/components/ui/Textarea.tsx
+++ b/components/ui/Textarea.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { forwardRef, TextareaHTMLAttributes } from 'react'
+import { forwardRef, TextareaHTMLAttributes, useId } from 'react'
 
 interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   label?: string
@@ -10,7 +10,8 @@ interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
 
 const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ label, error, helperText, className = '', id, ...props }, ref) => {
-    const textareaId = id || `textarea-${Math.random().toString(36).substr(2, 9)}`
+    const autoId = useId()
+    const textareaId = id || autoId
 
     return (
       <div className="w-full">

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, createContext, useContext, useCallback, useRef } from 'react'
+import { useState, useEffect, createContext, useContext, useCallback, useRef, useSyncExternalStore } from 'react'
 import { createPortal } from 'react-dom'
 import { Icon } from './Icon'
 import { useOptionalLanguage } from '@/lib/i18n/LanguageContext'
@@ -53,15 +53,17 @@ interface ToastProviderProps {
   maxToasts?: number
 }
 
+const subscribeNoop = () => () => {}
+
 export function ToastProvider({ children, position = 'bottom-right', maxToasts = 5 }: ToastProviderProps) {
   const lang = useOptionalLanguage()
   const t = lang?.t ?? ((k: string) => k)
   const [toasts, setToasts] = useState<Toast[]>([])
-  const [mounted, setMounted] = useState(false)
-
-  useEffect(() => {
-    setMounted(true)
-  }, [])
+  const mounted = useSyncExternalStore(
+    subscribeNoop,
+    () => true,
+    () => false
+  )
 
   const addToast = useCallback((toast: Omit<Toast, 'id'>) => {
     const id = Math.random().toString(36).substr(2, 9)

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -37,11 +37,14 @@ test.describe('home shell smoke', () => {
 
   test('reduced-motion hides background video', async ({ browser }) => {
     const context = await browser.newContext({ reducedMotion: 'reduce' })
-    const page = await context.newPage()
-    await mockSupabaseRest(page)
-    await page.goto('/')
-    await expect(page.locator('video')).toHaveCount(0)
-    await context.close()
+    try {
+      const page = await context.newPage()
+      await mockSupabaseRest(page)
+      await page.goto('/')
+      await expect(page.locator('video')).toHaveCount(0)
+    } finally {
+      await context.close()
+    }
   })
 
   test('album dialog opens with focus and closes on Escape', async ({ page }) => {

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -49,6 +49,7 @@ test.describe('home shell smoke', () => {
     await page.getByRole('button', { name: /VIEW MEMORY ALBUM|思い出アルバム/ }).first().click()
     const dialog = page.locator('[role="dialog"]').first()
     await expect(dialog).toBeVisible()
+    await expect(dialog.locator(':focus')).toBeVisible()
     await page.keyboard.press('Escape')
     await expect(dialog).not.toBeVisible()
   })
@@ -74,7 +75,7 @@ test.describe('home shell smoke', () => {
   test('camera capture exposes dialog semantics and Escape closes it', async ({ page }) => {
     await page.goto('/')
     await page.getByRole('button', { name: /SEND WISHES|お祝いメッセージ/ }).first().click()
-    await page.getByRole('button', { name: /Take video|ビデオを撮る/ }).first().click()
+    await page.getByRole('button', { name: /Record Video|ビデオを撮る/ }).first().click()
     const captureDialog = page.getByRole('dialog', { name: /Record Video|ビデオを撮る/ })
     await expect(captureDialog).toBeVisible()
     await page.keyboard.press('Escape')

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -5,25 +5,22 @@ const MOCK_MESSAGES = [
   { id: 1, sender: 'モック太郎', message: 'モック送信テスト', birthday_person: null, media_object_path: null, created_at: new Date().toISOString() },
 ]
 
-async function mockSupabaseRest(page: import('@playwright/test').Page, onPost?: (body: string) => void, withBroad = true) {
+async function mockSupabaseRest(page: import('@playwright/test').Page) {
   // 広域ハンドラを先に、messages 固有を後に登録（Playwright は後登録が優先）
-  if (withBroad) {
-    await page.route('**/*.supabase.co/**', (route) =>
-      route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
-    )
-    await page.route('**/storage/v1/**', (route) =>
-      route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
-    )
-    await page.route('**/auth/v1/**', (route) =>
-      route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
-    )
-    await page.route('**/rest/v1/**', (route) =>
-      route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
-    )
-  }
+  await page.route('**/*.supabase.co/**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+  )
+  await page.route('**/storage/v1/**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+  )
+  await page.route('**/auth/v1/**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
+  )
+  await page.route('**/rest/v1/**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+  )
   await page.route('**/rest/v1/messages**', async (route) => {
     if (route.request().method() === 'POST') {
-      onPost?.(route.request().postData() ?? '')
       return route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(MOCK_MESSAGES[0]) })
     }
     return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_MESSAGES) })
@@ -81,7 +78,7 @@ test.describe('home shell smoke', () => {
     const post = await postRequestPromise
     expect(post.postData()).toContain('モック送信テスト')
     await expect(form).not.toBeVisible()
-    await page.screenshot({ path: `tmp/browser-smoke/anon-post-success-${testInfo.project.name}.png`, fullPage: true })
+    await page.screenshot({ path: testInfo.outputPath('anon-post-success.png'), fullPage: true })
   })
 
   test('camera capture exposes dialog semantics and Escape closes it', async ({ page }) => {

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -8,6 +8,15 @@ const MOCK_MESSAGES = [
 async function mockSupabaseRest(page: import('@playwright/test').Page, onPost?: (body: string) => void, withBroad = true) {
   // 広域ハンドラを先に、messages 固有を後に登録（Playwright は後登録が優先）
   if (withBroad) {
+    await page.route('**/*.supabase.co/**', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+    )
+    await page.route('**/storage/v1/**', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+    )
+    await page.route('**/auth/v1/**', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
+    )
     await page.route('**/rest/v1/**', (route) =>
       route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
     )

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -57,7 +57,7 @@ test.describe('home shell smoke', () => {
     await expect(dialog).not.toBeVisible()
   })
 
-  test('anonymous message POST flows through mocked REST and closes the form', async ({ page }) => {
+  test('anonymous message POST flows through mocked REST and closes the form', async ({ page }, testInfo) => {
     await page.goto('/')
     const postRequestPromise = page.waitForRequest(
       (r) => r.method() === 'POST' && r.url().includes('/rest/v1/messages'),
@@ -65,14 +65,14 @@ test.describe('home shell smoke', () => {
     await page.getByRole('button', { name: /SEND WISHES|お祝いメッセージ/ }).first().click()
     const form = page.locator('form').filter({ has: page.getByRole('button', { name: /Send your wish|お祝いを送る/ }) }).first()
     await form.getByRole('textbox', { name: /Your name|あなたの名前/ }).fill('モック太郎')
-    await form.getByRole('textbox', { name: /Type a message|メッセージを入力/ }).fill('モック送信テスト')
+    await form.getByRole('textbox', { name: /Write your birthday message|Your birthday wish|Type your message|お祝いメッセージ|メッセージ/i }).fill('モック送信テスト')
     await form.getByRole('button', { name: /Send your wish|お祝いを送る/ }).click()
 
     // 成功時は onSuccess でモーダルが閉じる（成功コピーはフォーム内に表示されない設計）
     const post = await postRequestPromise
     expect(post.postData()).toContain('モック送信テスト')
     await expect(form).not.toBeVisible()
-    await page.screenshot({ path: 'tmp/browser-smoke/anon-post-success.png', fullPage: true })
+    await page.screenshot({ path: `tmp/browser-smoke/anon-post-success-${testInfo.project.name}.png`, fullPage: true })
   })
 
   test('camera capture exposes dialog semantics and Escape closes it', async ({ page }) => {

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,4 +1,4 @@
-﻿import { expect, test } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 
 // Supabase REST をモック（本番データ・本番書き込み不使用）
 const MOCK_MESSAGES = [
@@ -38,6 +38,7 @@ test.describe('home shell smoke', () => {
   test('reduced-motion hides background video', async ({ browser }) => {
     const context = await browser.newContext({ reducedMotion: 'reduce' })
     const page = await context.newPage()
+    await mockSupabaseRest(page)
     await page.goto('/')
     await expect(page.locator('video')).toHaveCount(0)
     await context.close()

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,82 @@
+﻿import { expect, test } from '@playwright/test'
+
+// Supabase REST をモック（本番データ・本番書き込み不使用）
+const MOCK_MESSAGES = [
+  { id: 1, sender: 'モック太郎', message: 'モック送信テスト', birthday_person: null, media_object_path: null, created_at: new Date().toISOString() },
+]
+
+async function mockSupabaseRest(page: import('@playwright/test').Page, onPost?: (body: string) => void, withBroad = true) {
+  // 広域ハンドラを先に、messages 固有を後に登録（Playwright は後登録が優先）
+  if (withBroad) {
+    await page.route('**/rest/v1/**', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+    )
+  }
+  await page.route('**/rest/v1/messages**', async (route) => {
+    if (route.request().method() === 'POST') {
+      onPost?.(route.request().postData() ?? '')
+      return route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(MOCK_MESSAGES[0]) })
+    }
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_MESSAGES) })
+  })
+}
+
+test.describe('home shell smoke', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockSupabaseRest(page)
+  })
+
+  test('mobile 390x844 has no horizontal overflow', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await page.goto('/')
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+    )
+    expect(overflow).toBe(false)
+  })
+
+  test('reduced-motion hides background video', async ({ browser }) => {
+    const context = await browser.newContext({ reducedMotion: 'reduce' })
+    const page = await context.newPage()
+    await page.goto('/')
+    await expect(page.locator('video')).toHaveCount(0)
+    await context.close()
+  })
+
+  test('album dialog opens with focus and closes on Escape', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: /VIEW MEMORY ALBUM|思い出アルバム/ }).first().click()
+    const dialog = page.locator('[role="dialog"]').first()
+    await expect(dialog).toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(dialog).not.toBeVisible()
+  })
+
+  test('anonymous message POST flows through mocked REST and closes the form', async ({ page }) => {
+    await page.goto('/')
+    const postRequestPromise = page.waitForRequest(
+      (r) => r.method() === 'POST' && r.url().includes('/rest/v1/messages'),
+    )
+    await page.getByRole('button', { name: /SEND WISHES|お祝いメッセージ/ }).first().click()
+    const form = page.locator('form').filter({ has: page.getByRole('button', { name: /Send your wish|お祝いを送る/ }) }).first()
+    await form.getByRole('textbox', { name: /Your name|あなたの名前/ }).fill('モック太郎')
+    await form.getByRole('textbox', { name: /Type a message|メッセージを入力/ }).fill('モック送信テスト')
+    await form.getByRole('button', { name: /Send your wish|お祝いを送る/ }).click()
+
+    // 成功時は onSuccess でモーダルが閉じる（成功コピーはフォーム内に表示されない設計）
+    const post = await postRequestPromise
+    expect(post.postData()).toContain('モック送信テスト')
+    await expect(form).not.toBeVisible()
+    await page.screenshot({ path: 'tmp/browser-smoke/anon-post-success.png', fullPage: true })
+  })
+
+  test('camera capture exposes dialog semantics and Escape closes it', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: /SEND WISHES|お祝いメッセージ/ }).first().click()
+    await page.getByRole('button', { name: /Take video|ビデオを撮る/ }).first().click()
+    const captureDialog = page.getByRole('dialog', { name: /Record Video|ビデオを撮る/ })
+    await expect(captureDialog).toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(captureDialog).not.toBeVisible()
+  })
+})

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,11 +7,14 @@ const eslintConfig = defineConfig([
   ...nextTs,
   // eslint-config-next のデフォルトの ignore 設定を上書き
   globalIgnores([
-    // eslint-config-next のデフォルト ignore 対象
     ".next/**",
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // ツールリング生成物・ローカル作業領域はリント対象外
+    ".gitnexus/**",
+    ".claude/**",
+    "tmp/**",
   ]),
 ]);
 

--- a/lib/healthcheck.ts
+++ b/lib/healthcheck.ts
@@ -1,0 +1,43 @@
+'use client'
+
+export interface HealthcheckResult {
+  ok: boolean
+  status: number | null
+  detail: string
+}
+
+/**
+ * Supabase REST エンドポイントへの読み取り専用ヘルスチェック。
+ * 書き込みは行わず、タイムアウト付きで到達性と認証のみ確認する。
+ */
+export async function checkSupabaseReadonly(
+  timeoutMs: number = 5000,
+  fetchImpl: typeof fetch = fetch,
+): Promise<HealthcheckResult> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+
+  try {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+    const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    if (!supabaseUrl || !supabaseKey) {
+      return { ok: false, status: null, detail: 'supabase-not-configured' }
+    }
+
+    const response = await fetchImpl(`${supabaseUrl}/rest/v1/`, {
+      method: 'GET',
+      signal: controller.signal,
+      headers: {
+        apikey: supabaseKey,
+        Authorization: `Bearer ${supabaseKey}`,
+      },
+    })
+
+    return { ok: response.ok, status: response.status, detail: response.ok ? 'reachable' : 'unhealthy' }
+  } catch (error) {
+    const aborted = error instanceof Error && error.name === 'AbortError'
+    return { ok: false, status: null, detail: aborted ? 'timeout' : 'network-error' }
+  } finally {
+    clearTimeout(timer)
+  }
+}

--- a/lib/hooks/useMediaQuery.ts
+++ b/lib/hooks/useMediaQuery.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback, useSyncExternalStore } from 'react'
 
 // Tailwind CSS のブレークポイントに対応した値
 export const breakpoints = {
@@ -12,23 +12,18 @@ export const breakpoints = {
 }
 
 export function useMediaQuery(query: string): boolean {
-  const [matches, setMatches] = useState(false)
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      const mediaQuery = window.matchMedia(query)
+      mediaQuery.addEventListener('change', onStoreChange)
+      return () => mediaQuery.removeEventListener('change', onStoreChange)
+    },
+    [query]
+  )
 
-  useEffect(() => {
-    if (typeof window === 'undefined') return
+  const getSnapshot = useCallback(() => window.matchMedia(query).matches, [query])
 
-    const mediaQuery = window.matchMedia(query)
-    setMatches(mediaQuery.matches)
-
-    const handler = (event: MediaQueryListEvent) => {
-      setMatches(event.matches)
-    }
-
-    mediaQuery.addEventListener('change', handler)
-    return () => mediaQuery.removeEventListener('change', handler)
-  }, [query])
-
-  return matches
+  return useSyncExternalStore(subscribe, getSnapshot, () => false)
 }
 
 // よく使うブレークポイント用の補助フック
@@ -50,13 +45,10 @@ export function useIsLargeDesktop(): boolean {
 
 // タッチデバイスかどうかを判定
 export function useIsTouchDevice(): boolean {
-  const [isTouch, setIsTouch] = useState(false)
+  const subscribe = useCallback(() => () => {}, [])
+  const getSnapshot = useCallback(() => 'ontouchstart' in window || navigator.maxTouchPoints > 0, [])
 
-  useEffect(() => {
-    setIsTouch('ontouchstart' in window || navigator.maxTouchPoints > 0)
-  }, [])
-
-  return isTouch
+  return useSyncExternalStore(subscribe, getSnapshot, () => false)
 }
 
 // 動きの軽減設定（reduced motion）の有無を判定

--- a/lib/hooks/usePosts.ts
+++ b/lib/hooks/usePosts.ts
@@ -21,6 +21,16 @@ type PostRecord = Omit<Post, 'media_url' | 'replies_count' | 'likes'> & {
   post_replies?: { count: number }[]
 }
 
+interface PostsQueryError {
+  message?: string | null
+  code?: string | null
+}
+
+interface PostsQueryResult {
+  data: PostRecord[] | null
+  error: PostsQueryError | null
+}
+
 function toPost(post: PostRecord): Post {
   const { data } = post.media_object_path
     ? getSupabase().storage.from('community-media').getPublicUrl(post.media_object_path)
@@ -49,7 +59,7 @@ export function usePosts() {
     setError(null)
 
     try {
-      let queryResult: any = await getSupabase()
+      let queryResult: PostsQueryResult = await getSupabase()
         .from('bulletin_posts')
         .select('id, sender, message, media_object_path, birthday_person, created_at, likes, post_replies(count)')
         .order('created_at', { ascending: false })
@@ -62,7 +72,7 @@ export function usePosts() {
       }
 
       if (queryResult.error) throw queryResult.error
-      setPosts((queryResult.data ?? []).map((post: any) => toPost(post as PostRecord)))
+      setPosts((queryResult.data ?? []).map((post) => toPost(post as PostRecord)))
     } catch (err) {
       console.error('Failed to fetch posts:', err)
       setError(tRef.current('postsLoadError'))

--- a/lib/hooks/useRealtimeMessages.ts
+++ b/lib/hooks/useRealtimeMessages.ts
@@ -24,7 +24,7 @@ export function useRealtimeMessages({
   const subscribe = useCallback(() => {
     const supabase = getSupabase()
     
-    let channel: RealtimeChannel = supabase
+    const channel: RealtimeChannel = supabase
       .channel(`${table}_changes`)
       .on(
         'postgres_changes',

--- a/lib/hooks/useSlideshow.ts
+++ b/lib/hooks/useSlideshow.ts
@@ -64,7 +64,8 @@ export function useSlideshow(
   // メディアが変更されたらインデックスをリセット
   useEffect(() => {
     if (currentIndex >= media.length) {
-      setCurrentIndex(0)
+      const raf = requestAnimationFrame(() => setCurrentIndex(0))
+      return () => cancelAnimationFrame(raf)
     }
   }, [media.length, currentIndex])
 

--- a/lib/hooks/useTheme.ts
+++ b/lib/hooks/useTheme.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useCallback } from 'react'
 import { detectSeasonAndFestival, getThemeConfig } from '@/lib/utils/theme'
 import type { ThemeName } from '@/types'
 import type { ThemeConfig } from '@/config/themes'
@@ -21,14 +21,6 @@ function getInitialTheme(): ThemeName {
 export function useTheme(): UseThemeReturn {
   const [theme, setThemeState] = useState<ThemeName>(getInitialTheme)
   const [isAutoDetect, setIsAutoDetect] = useState(true)
-
-  // マウント後にテーマを検出
-  useEffect(() => {
-    if (isAutoDetect) {
-      const detectedTheme = detectSeasonAndFestival()
-      setThemeState(detectedTheme)
-    }
-  }, [isAutoDetect])
 
   // 手動でテーマを設定
   const setTheme = useCallback((newTheme: ThemeName) => {

--- a/lib/hooks/useUserName.ts
+++ b/lib/hooks/useUserName.ts
@@ -6,6 +6,8 @@ const STORAGE_KEY = 'birthday_user_name'
 
 const listeners = new Set<() => void>()
 
+let inMemoryFallback: string | null = null
+
 function emitChange() {
   for (const listener of listeners) {
     listener()
@@ -15,20 +17,32 @@ function emitChange() {
 function subscribe(callback: () => void) {
   if (typeof window === 'undefined') return () => {}
   listeners.add(callback)
-  window.addEventListener('storage', callback)
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key === STORAGE_KEY || event.key === null) {
+      inMemoryFallback = null
+      callback()
+    }
+  }
+  window.addEventListener('storage', handleStorage)
   return () => {
     listeners.delete(callback)
-    window.removeEventListener('storage', callback)
+    window.removeEventListener('storage', handleStorage)
   }
 }
 
 function getSnapshot() {
   if (typeof window === 'undefined') return ''
   try {
-    return localStorage.getItem(STORAGE_KEY) || ''
-  } catch {
+    const item = localStorage.getItem(STORAGE_KEY)
+    if (item !== null) {
+      inMemoryFallback = null
+      return item
+    }
+  } catch (_error: unknown) {
+    if (inMemoryFallback !== null) return inMemoryFallback
     return ''
   }
+  return inMemoryFallback ?? ''
 }
 
 function getServerSnapshot() {
@@ -43,13 +57,16 @@ export function useUserName() {
     () => false
   )
 
-  // localStorageに保存
+  // localStorageに保存（例外発生時はメモリ内フォールバックを維持）
   const setUserName = useCallback((name: string) => {
     const trimmed = name.trim()
     if (trimmed) {
       try {
         localStorage.setItem(STORAGE_KEY, trimmed)
-      } catch {}
+        inMemoryFallback = null
+      } catch (_error: unknown) {
+        inMemoryFallback = trimmed
+      }
       emitChange()
     }
   }, [])
@@ -58,7 +75,10 @@ export function useUserName() {
   const clearUserName = useCallback(() => {
     try {
       localStorage.removeItem(STORAGE_KEY)
-    } catch {}
+      inMemoryFallback = null
+    } catch (_error: unknown) {
+      inMemoryFallback = ''
+    }
     emitChange()
   }, [])
 

--- a/lib/hooks/useUserName.ts
+++ b/lib/hooks/useUserName.ts
@@ -1,13 +1,25 @@
 'use client'
 
-import { useState, useCallback, useSyncExternalStore } from 'react'
+import { useCallback, useSyncExternalStore } from 'react'
 
 const STORAGE_KEY = 'birthday_user_name'
 
+const listeners = new Set<() => void>()
+
+function emitChange() {
+  for (const listener of listeners) {
+    listener()
+  }
+}
+
 function subscribe(callback: () => void) {
   if (typeof window === 'undefined') return () => {}
+  listeners.add(callback)
   window.addEventListener('storage', callback)
-  return () => window.removeEventListener('storage', callback)
+  return () => {
+    listeners.delete(callback)
+    window.removeEventListener('storage', callback)
+  }
 }
 
 function getSnapshot() {
@@ -24,15 +36,12 @@ function getServerSnapshot() {
 }
 
 export function useUserName() {
-  const storedName = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
-  const [localOverride, setLocalOverride] = useState<string | null>(null)
+  const userName = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
   const mounted = useSyncExternalStore(
     () => () => {},
     () => true,
     () => false
   )
-
-  const userName = localOverride !== null ? localOverride : storedName
 
   // localStorageに保存
   const setUserName = useCallback((name: string) => {
@@ -41,7 +50,7 @@ export function useUserName() {
       try {
         localStorage.setItem(STORAGE_KEY, trimmed)
       } catch {}
-      setLocalOverride(trimmed)
+      emitChange()
     }
   }, [])
 
@@ -50,7 +59,7 @@ export function useUserName() {
     try {
       localStorage.removeItem(STORAGE_KEY)
     } catch {}
-    setLocalOverride('')
+    emitChange()
   }, [])
 
   return {

--- a/lib/hooks/useUserName.ts
+++ b/lib/hooks/useUserName.ts
@@ -10,11 +10,14 @@ export function useUserName() {
 
   // マウント時にlocalStorageから読み込み
   useEffect(() => {
-    const stored = localStorage.getItem(STORAGE_KEY)
-    if (stored) {
-      setUserNameState(stored)
-    }
-    setIsLoaded(true)
+    const raf = requestAnimationFrame(() => {
+      const stored = localStorage.getItem(STORAGE_KEY)
+      if (stored) {
+        setUserNameState(stored)
+      }
+      setIsLoaded(true)
+    })
+    return () => cancelAnimationFrame(raf)
   }, [])
 
   // localStorageに保存

--- a/lib/hooks/useUserName.ts
+++ b/lib/hooks/useUserName.ts
@@ -1,45 +1,63 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useCallback, useSyncExternalStore } from 'react'
 
 const STORAGE_KEY = 'birthday_user_name'
 
-export function useUserName() {
-  const [userName, setUserNameState] = useState<string>('')
-  const [isLoaded, setIsLoaded] = useState(false)
+function subscribe(callback: () => void) {
+  if (typeof window === 'undefined') return () => {}
+  window.addEventListener('storage', callback)
+  return () => window.removeEventListener('storage', callback)
+}
 
-  // マウント時にlocalStorageから読み込み
-  useEffect(() => {
-    const raf = requestAnimationFrame(() => {
-      const stored = localStorage.getItem(STORAGE_KEY)
-      if (stored) {
-        setUserNameState(stored)
-      }
-      setIsLoaded(true)
-    })
-    return () => cancelAnimationFrame(raf)
-  }, [])
+function getSnapshot() {
+  if (typeof window === 'undefined') return ''
+  try {
+    return localStorage.getItem(STORAGE_KEY) || ''
+  } catch {
+    return ''
+  }
+}
+
+function getServerSnapshot() {
+  return ''
+}
+
+export function useUserName() {
+  const storedName = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+  const [localOverride, setLocalOverride] = useState<string | null>(null)
+  const mounted = useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false
+  )
+
+  const userName = localOverride !== null ? localOverride : storedName
 
   // localStorageに保存
   const setUserName = useCallback((name: string) => {
     const trimmed = name.trim()
     if (trimmed) {
-      localStorage.setItem(STORAGE_KEY, trimmed)
-      setUserNameState(trimmed)
+      try {
+        localStorage.setItem(STORAGE_KEY, trimmed)
+      } catch {}
+      setLocalOverride(trimmed)
     }
   }, [])
 
   // 保存された名前をクリア
   const clearUserName = useCallback(() => {
-    localStorage.removeItem(STORAGE_KEY)
-    setUserNameState('')
+    try {
+      localStorage.removeItem(STORAGE_KEY)
+    } catch {}
+    setLocalOverride('')
   }, [])
 
   return {
     userName,
     setUserName,
     clearUserName,
-    isLoaded,
+    isLoaded: mounted,
     hasUserName: !!userName,
   }
 }

--- a/lib/stores/uiStore.ts
+++ b/lib/stores/uiStore.ts
@@ -23,31 +23,61 @@ interface UIState {
 
 // モーダルを開く直前にフォーカスされていた要素（閉じた際の復元先）
 let lastModalTrigger: HTMLElement | null = null
+let restoreRafId: number | null = null
+
+function isVisible(el: HTMLElement): boolean {
+  if (!el.isConnected || el.hasAttribute('disabled') || el.getAttribute('aria-hidden') === 'true') {
+    return false
+  }
+  if (el.style.display === 'none' || el.style.visibility === 'hidden') {
+    return false
+  }
+  return true
+}
+
+function findVisibleFallback(): HTMLElement | null {
+  if (typeof document === 'undefined') return null
+  const candidates = document.querySelectorAll<HTMLElement>(
+    'header button:not([disabled]), nav button:not([disabled]), .mobile-game-toggle:not([disabled]), main button:not([disabled])'
+  )
+  for (let i = 0; i < candidates.length; i++) {
+    const el = candidates[i]
+    if (isVisible(el)) return el
+  }
+  return null
+}
 
 // モーダル unmount 後にトリガーへフォーカスを返す共有ライフサイクル。
 // 個別モーダル側の restore が unmount 順序で失敗しても、ここで最終保証する。
 function restoreTriggerFocus(): void {
   if (typeof window === 'undefined') return
-  requestAnimationFrame(() => {
+  if (restoreRafId !== null) {
+    cancelAnimationFrame(restoreRafId)
+  }
+  restoreRafId = requestAnimationFrame(() => {
+    restoreRafId = null
     const active = document.activeElement
     if (active === document.body || active === null) {
-      if (lastModalTrigger?.isConnected) {
+      if (lastModalTrigger && isVisible(lastModalTrigger)) {
         lastModalTrigger.focus()
       } else {
-        // トリガー要素が unmount された場合（モバイルメニュー等）、永続的なナビゲーションボタンへ安全にフォールバック
-        const fallback = document.querySelector(
-          'header button:not([disabled]), nav button:not([disabled]), .mobile-game-toggle:not([disabled]), main button:not([disabled])'
-        ) as HTMLElement | null
+        // トリガー要素が unmount/非表示化された場合（モバイルメニュー等）、永続的かつ可視なナビゲーションボタンへ安全にフォールバック
+        const fallback = findVisibleFallback()
         fallback?.focus()
       }
     }
   })
 }
 
-export const useUIStore = create<UIState>((set) => ({
+export const useUIStore = create<UIState>((set, get) => ({
   activeModal: null,
   openModal: (modal) => {
-    if (typeof document !== 'undefined') {
+    if (restoreRafId !== null) {
+      cancelAnimationFrame(restoreRafId)
+      restoreRafId = null
+    }
+    // 最初のモーダル展開時のみページ上の起動元トリガーを記録（モーダル間直接遷移時は元のトリガーを維持）
+    if (typeof document !== 'undefined' && get().activeModal === null) {
       lastModalTrigger =
         document.activeElement instanceof HTMLElement ? document.activeElement : null
     }

--- a/lib/stores/uiStore.ts
+++ b/lib/stores/uiStore.ts
@@ -30,8 +30,16 @@ function restoreTriggerFocus(): void {
   if (typeof window === 'undefined') return
   requestAnimationFrame(() => {
     const active = document.activeElement
-    if ((active === document.body || active === null) && lastModalTrigger?.isConnected) {
-      lastModalTrigger.focus()
+    if (active === document.body || active === null) {
+      if (lastModalTrigger?.isConnected) {
+        lastModalTrigger.focus()
+      } else {
+        // トリガー要素が unmount された場合（モバイルメニュー等）、永続的なナビゲーションボタンへ安全にフォールバック
+        const fallback = document.querySelector(
+          'header button:not([disabled]), nav button:not([disabled]), .mobile-game-toggle:not([disabled]), main button:not([disabled])'
+        ) as HTMLElement | null
+        fallback?.focus()
+      }
     }
   })
 }

--- a/lib/stores/uiStore.ts
+++ b/lib/stores/uiStore.ts
@@ -21,8 +21,33 @@ interface UIState {
   closeModal: () => void
 }
 
+// モーダルを開く直前にフォーカスされていた要素（閉じた際の復元先）
+let lastModalTrigger: HTMLElement | null = null
+
+// モーダル unmount 後にトリガーへフォーカスを返す共有ライフサイクル。
+// 個別モーダル側の restore が unmount 順序で失敗しても、ここで最終保証する。
+function restoreTriggerFocus(): void {
+  if (typeof window === 'undefined') return
+  requestAnimationFrame(() => {
+    const active = document.activeElement
+    if ((active === document.body || active === null) && lastModalTrigger?.isConnected) {
+      lastModalTrigger.focus()
+    }
+  })
+}
+
 export const useUIStore = create<UIState>((set) => ({
   activeModal: null,
-  openModal: (modal) => set({ activeModal: modal }),
-  closeModal: () => set({ activeModal: null }),
+  openModal: (modal) => {
+    if (typeof document !== 'undefined') {
+      lastModalTrigger =
+        document.activeElement instanceof HTMLElement ? document.activeElement : null
+    }
+    set({ activeModal: modal })
+  },
+  closeModal: () => {
+    set({ activeModal: null })
+    // lastModalTrigger は次回 open で上書きするため、ここではクリアしない
+    restoreTriggerFocus()
+  },
 }))

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "zustand": "^5.0.9"
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.1",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
@@ -1961,6 +1962,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -7562,6 +7579,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^5.1.1",
+        "@vitest/coverage-v8": "^4.1.11",
         "babel-plugin-react-compiler": "1.0.0",
         "eslint": "^9",
         "eslint-config-next": "16.0.7",
@@ -270,9 +271,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -280,9 +281,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -314,13 +315,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -406,17 +407,27 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -2317,9 +2328,9 @@
       "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
@@ -3594,32 +3605,63 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
-    "node_modules/@vitest/expect": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.15.tgz",
-      "integrity": "sha512-Gfyva9/GxPAWXIWjyGDli9O+waHDC0Q0jaLdFP1qPAUUfo1FEXPXUfUkp3eZA0sSq340vPycSyOlYUeM15Ft1w==",
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.11.tgz",
+      "integrity": "sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.11",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.11",
+        "vitest": "4.1.11"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.15",
-        "@vitest/utils": "4.0.15",
-        "chai": "^6.2.1",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.15.tgz",
-      "integrity": "sha512-CZ28GLfOEIFkvCFngN8Sfx5h+Se0zN+h4B7yOsPVCcgtiO7t5jt9xQh2E1UkFep+eb9fjyMfuC5gBypwb07fvQ==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.0.15",
+        "@vitest/spy": "4.1.11",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -3628,7 +3670,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -3640,26 +3682,26 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.15.tgz",
-      "integrity": "sha512-SWdqR8vEv83WtZcrfLNqlqeQXlQLh2iilO1Wk1gv4eiHKjEzvgHb2OVc3mIPyhZE6F+CtfYjNlDJwP5MN6Km7A==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.15.tgz",
-      "integrity": "sha512-+A+yMY8dGixUhHmNdPUxOh0la6uVzun86vAbuMT3hIDxMrAOmn5ILBHm8ajrqHE0t8R9T1dGnde1A5DTnmi3qw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.15",
+        "@vitest/utils": "4.1.11",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -3667,13 +3709,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.15.tgz",
-      "integrity": "sha512-A7Ob8EdFZJIBjLjeO0DZF4lqR6U7Ydi5/5LIZ0xcI+23lYlsYJAfGn8PrIWTYdZQRNnSRlzhg0zyGu37mVdy5g==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.15",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -3682,9 +3725,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.15.tgz",
-      "integrity": "sha512-+EIjOJmnY6mIfdXtE/bnozKEvTC4Uczg19yeZ2vtCz5Yyb0QQ31QWVQ8hswJ3Ysx/K2EqaNsVanjr//2+P3FHw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3692,14 +3735,15 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.15.tgz",
-      "integrity": "sha512-HXjPW2w5dxhTD0dLwtYHDnelK3j8sR8cWIaLxr22evTyY6q8pRCjZSmhRWVjBaOVXChQd6AwMzi9pucorXCPZA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.15",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -3976,6 +4020,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -4209,9 +4272,9 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.1.tgz",
-      "integrity": "sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4702,9 +4765,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5284,9 +5347,9 @@
       }
     },
     "node_modules/expect-type": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
-      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -5824,6 +5887,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -6373,6 +6443,45 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -6901,6 +7010,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/math-intrinsics": {
@@ -8130,9 +8280,9 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
     },
@@ -8448,9 +8598,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8898,31 +9048,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.15.tgz",
-      "integrity": "sha512-n1RxDp8UJm6N0IbJLQo+yzLZ2sQCDyl1o0LeugbPWf8+8Fttp29GghsQBjYJVmWq3gBFfe9Hs1spR44vovn2wA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.0.15",
-        "@vitest/mocker": "4.0.15",
-        "@vitest/pretty-format": "4.0.15",
-        "@vitest/runner": "4.0.15",
-        "@vitest/snapshot": "4.0.15",
-        "@vitest/spy": "4.0.15",
-        "@vitest/utils": "4.0.15",
-        "es-module-lexer": "^1.7.0",
-        "expect-type": "^1.2.2",
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
         "obug": "^2.1.1",
         "pathe": "^2.0.3",
         "picomatch": "^4.0.3",
-        "std-env": "^3.10.0",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -8938,12 +9088,15 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.15",
-        "@vitest/browser-preview": "4.0.15",
-        "@vitest/browser-webdriverio": "4.0.15",
-        "@vitest/ui": "4.0.15",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -8964,6 +9117,12 @@
         "@vitest/browser-webdriverio": {
           "optional": true
         },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
         "@vitest/ui": {
           "optional": true
         },
@@ -8972,6 +9131,9 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "zustand": "^5.0.9"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "predev": "npm run generate:data",
     "prebuild": "npm run generate:data",
     "pretest": "node scripts/generate-data-manifest.mjs --check",
+    "pretypecheck": "npm run generate:data",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.86.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage"
@@ -43,6 +44,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^5.1.1",
+    "@vitest/coverage-v8": "^4.1.11",
     "babel-plugin-react-compiler": "1.0.0",
     "eslint": "^9",
     "eslint-config-next": "16.0.7",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test'
+
+// ブラウザスモークテスト。本番データは使わず Supabase REST をモックする。
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 45_000,
+  retries: 0,
+  outputDir: 'tmp/browser-smoke/test-results',
+  use: {
+    baseURL: 'http://localhost:3000',
+    screenshot: 'only-on-failure',
+    launchOptions: {
+      args: ['--use-fake-ui-for-media-stream', '--use-fake-device-for-media-stream'],
+    },
+  },
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+  projects: [
+    { name: 'desktop', use: { ...devices['Desktop Chrome'] } },
+    { name: 'mobile', use: { ...devices['Pixel 7'] } },
+  ],
+})

--- a/scripts/generate-data-manifest.mjs
+++ b/scripts/generate-data-manifest.mjs
@@ -364,6 +364,17 @@ async function generate(root) {
   return generatedContents(packs, locales, themeKeys, translationKeys)
 }
 
+async function ensureNextEnv(root) {
+  const nextEnvPath = join(root, 'next-env.d.ts')
+  if (!existsSync(nextEnvPath)) {
+    await writeFile(
+      nextEnvPath,
+      '/// <reference types="next" />\n/// <reference types="next/image-types/global" />\n\n// NOTE: This file should not be edited\n// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.\n',
+      'utf8'
+    )
+  }
+}
+
 async function main() {
   const args = process.argv.slice(2)
   const rootIndex = args.indexOf('--root')
@@ -381,6 +392,7 @@ async function main() {
     }
     return
   }
+  await ensureNextEnv(root)
   await writeAtomically(root, contents)
 }
 

--- a/scripts/generate-data-manifest.mjs
+++ b/scripts/generate-data-manifest.mjs
@@ -364,17 +364,6 @@ async function generate(root) {
   return generatedContents(packs, locales, themeKeys, translationKeys)
 }
 
-async function ensureNextEnv(root) {
-  const nextEnvPath = join(root, 'next-env.d.ts')
-  if (!existsSync(nextEnvPath)) {
-    await writeFile(
-      nextEnvPath,
-      '/// <reference types="next" />\n/// <reference types="next/image-types/global" />\n\n// NOTE: This file should not be edited\n// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.\n',
-      'utf8'
-    )
-  }
-}
-
 async function main() {
   const args = process.argv.slice(2)
   const rootIndex = args.indexOf('--root')
@@ -392,7 +381,6 @@ async function main() {
     }
     return
   }
-  await ensureNextEnv(root)
   await writeAtomically(root, contents)
 }
 

--- a/supabase/migrations/20260823000000_harden_avatar_storage_mime_types.sql
+++ b/supabase/migrations/20260823000000_harden_avatar_storage_mime_types.sql
@@ -1,0 +1,24 @@
+begin;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from storage.buckets
+    where id = 'avatars'
+  ) then
+    raise exception 'storage bucket avatars does not exist';
+  end if;
+end
+$$;
+
+update storage.buckets
+set allowed_mime_types = array[
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/gif'
+]::text[]
+where id = 'avatars';
+
+commit;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules", "vitest.config.ts", "vitest.setup.ts", "happy-birthday-production"]
+  "exclude": ["node_modules", "happy-birthday-production"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
@@ -13,7 +13,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
-      exclude: ['node_modules', '.next', '**/*.d.ts', '**/*.config.*', '.claude/**', '.agents/**'],
+      exclude: ['node_modules', '.next', '**/*.d.ts', '**/*.config.*', '.claude/**', '.agents/**', '__tests__/scripts/**'],
     },
   },
   resolve: {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,4 +1,4 @@
-import '@testing-library/jest-dom'
+import '@testing-library/jest-dom/vitest'
 import { vi } from 'vitest'
 
 Object.defineProperty(window, 'matchMedia', {


### PR DESCRIPTION
## 概要
未解決の運用・品質・アクセシビリティ・データ契約の課題を、単一の作業ブランチで段階的に解消しました。既存の visual identity、animation、匿名投稿モデルを維持し、本番 Supabase の変更は承認対象として分離しています。

## 実装チェックリスト
- [x] #2 匿名権限、Storage 方針、healthcheck、運用手順を整備する（read-only healthcheck、境界テスト、browser mock verification、production Storage 再確認、avatars SVG 制限、schedule workflow は完了。Repository secrets の設定と実行確認は未完了）
- [x] #3 typecheck、coverage、Lint、回帰テスト、最小 CI workflow を整備する
- [x] #4 keyboard、focus、dialog、reduced-motion、mobile 操作性を整備する（Playwright desktop/mobile smoke 10/10 と focus regression 3/3 を確認済み）
- [x] #5 匿名コミュニティの abuse control、保持、通報、moderation、browser verification、theme token 移行方針を整備する（production の retention / rate limit / moderation enforcement は別途運用承認事項）
- [x] #7 Cubic follow-up round 7 の data pack、generator、CLI、SSR locale、policy 残差分を解消する

## 検証チェックリスト
- [x] 各 Issue の targeted test を個別に実行する
- [x] typecheck、Lint、test、build を個別に実行する
- [x] keyboard、small screen、reduced-motion の確認結果を記録する（Playwright desktop/mobile 10/10）
- [x] Supabase production の承認済み Storage scope を read-only 再確認し、avatars MIME hardening migration を適用・検証する
- [x] production migration、deployment、secret、外部送信を実行していないことを確認する（承認済みの avatars migration を除く）
- [x] `git diff --check` と変更範囲を確認する
- [x] レビューコメントと CI 結果を確認してから ready-for-review に変更する

## 作業方針
- コード、テスト、ローカル文書を Issue ごとの batch に分けて実装しました。
- `exam` の production 変更は、承認済みの avatars MIME hardening に限定しました。retention、rate limit、moderation queue は未確定のため実施していません。
- Supabase healthcheck workflow は Repository secrets を参照し、未設定時は失敗として可視化します。secret 値はリポジトリに保存しません。
- #9 と #18 はユーザー確認済みのため、この PR の対象外です。
- OpenCode は commit、push、GitHub 操作、本番 Supabase 操作を行っていません。

## 検証結果
- 最新の local targeted / full verification: 30 files / 210 tests pass
- Playwright browser smoke: desktop/mobile 10/10 pass
- focus regression: 3/3 pass
- `npm run typecheck`: pass
- `npm run lint`: 0 errors、既存 warnings のみ
- `npm run build`: pass
- `git diff --check`: pass
- PR CI after `c92e38b`: `verify` success
- Vercel Preview Comments after `c92e38b`: success
- Cubic: `No issues found` on `4c1a36a`; latest commits add only production docs/workflow and no application behavior changes
- Supabase `exam`: avatars bucket verified as JPEG/PNG/WebP/GIF only, 5 MiB, public; migration recorded as `20260823045356`

## References
Refs #2
Refs #3
Refs #4
Refs #5
Refs #7