### PR TITLE
タイムカプセルの安全性・型安全性・検証基盤を整える

### DIFF
--- a/__tests__/components/TimeCapsule.test.tsx
+++ b/__tests__/components/TimeCapsule.test.tsx
@@ -263,7 +263,7 @@ describe('TimeCapsule', () => {
     expect(localStorage.getItem('local_time_capsules')).toBeNull()
   })
 
-  it('cleans up the unlock interval on unmount', async () => {
+  it('cleans up the refresh interval on unmount', async () => {
     const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval')
     getSupabaseMock.mockReturnValue(createSupabaseStub())
     const { unmount } = render(<TimeCapsule />)

--- a/__tests__/components/TimeCapsule.test.tsx
+++ b/__tests__/components/TimeCapsule.test.tsx
@@ -256,6 +256,52 @@ describe('TimeCapsule', () => {
     expect(screen.getByRole('button', { name: 'retry' })).toBeTruthy()
   })
 
+  it('preserves loaded capsules when a refresh query fails', async () => {
+    let openedCalls = 0
+    let sealedCalls = 0
+    getSupabaseMock.mockReturnValue({
+      from: (table: string) => ({
+        select: () => ({
+          lte: () => ({
+            order: async () => {
+              openedCalls += 1
+              return openedCalls === 1
+                ? { data: [row({ id: 1, sender: '開封済み', unlock_date: pastDate })], error: null }
+                : { data: [], error: null }
+            },
+          }),
+          gt: () => ({
+            order: async () => {
+              sealedCalls += 1
+              return { data: [], error: new Error('sealed query failed') }
+            },
+          }),
+        }),
+        insert: async () => ({ error: table === 'time_capsules' ? null : null }),
+      }),
+      storage: {
+        from: () => ({
+          upload: async () => ({ data: null, error: null }),
+          getPublicUrl: () => ({ data: { publicUrl: '' } }),
+        }),
+      },
+    } satisfies SupabaseStub)
+
+    render(<TimeCapsule />)
+    expect(await screen.findByText('開封済み')).toBeTruthy()
+    expect(await screen.findByText('genericError')).toBeTruthy()
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'retry' }))
+    })
+
+    await vi.waitFor(() => {
+      expect(openedCalls).toBe(2)
+      expect(sealedCalls).toBe(2)
+    })
+    expect(screen.getByText('開封済み')).toBeTruthy()
+    expect(await screen.findByText('genericError')).toBeTruthy()
+  })
+
   it('formats locked dates for English users', async () => {
     languageMock.value = 'en'
     getSupabaseMock.mockReturnValue(createSupabaseStub({ sealedRows: [row()] }))

--- a/__tests__/components/TimeCapsule.test.tsx
+++ b/__tests__/components/TimeCapsule.test.tsx
@@ -1,0 +1,257 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import TimeCapsule, {
+  parseLocalCapsules,
+  parseRemoteCapsule,
+} from '@/components/community/TimeCapsule'
+
+const getSupabaseMock = vi.fn()
+const languageMock = vi.hoisted(() => ({ value: 'ja' as 'ja' | 'en' }))
+
+type CapsuleRow = {
+  id: number
+  sender: string
+  recipient: string | null
+  message: string
+  photo_url: string | null
+  unlock_date: string
+  created_at: string
+}
+
+type QueryResult = { data: CapsuleRow[]; error: Error | null }
+
+type SupabaseStub = {
+  from: (table: string) => {
+    select: (columns: string) => {
+      lte: () => { order: () => Promise<QueryResult> }
+      gt: () => { order: () => Promise<QueryResult> }
+    }
+    insert: (payload: Record<string, unknown>) => Promise<{ error: Error | null }>
+  }
+  storage: {
+    from: (bucket: string) => {
+      upload: (path: string, file: File) => Promise<{
+        data: { path: string } | null
+        error: Error | null
+      }>
+      getPublicUrl: (path: string) => { data: { publicUrl: string } }
+    }
+  }
+}
+
+vi.mock('@/lib/i18n/LanguageContext', () => ({
+  useLanguage: () => ({
+    language: languageMock.value,
+    t: (key: string, params?: { date?: string }) => `${key}${params?.date ? `:${params.date}` : ''}`,
+  }),
+}))
+
+vi.mock('@/components/ui/Icon', () => ({
+  Icon: ({ name }: { name: string }) => <span data-testid={`icon-${name}`} />,
+}))
+
+vi.mock('@/lib/supabase/client', () => ({
+  getSupabase: () => getSupabaseMock(),
+}))
+
+function createSupabaseStub({
+  openedRows = [],
+  sealedRows = [],
+  selectError = null,
+  insertError = null,
+  uploadError = null,
+  selectCalls = [],
+}: {
+  openedRows?: CapsuleRow[]
+  sealedRows?: CapsuleRow[]
+  selectError?: Error | null
+  insertError?: Error | null
+  uploadError?: Error | null
+  selectCalls?: string[]
+} = {}): SupabaseStub {
+  const from = (table: string) => {
+    const query = {
+      lte: () => ({ order: async () => ({ data: openedRows, error: selectError }) }),
+      gt: () => ({ order: async () => ({ data: sealedRows, error: selectError }) }),
+    }
+
+    return {
+      select: (columns: string) => {
+        if (table === 'time_capsules') selectCalls.push(columns)
+        return query
+      },
+      insert: async () => ({ error: table === 'time_capsules' ? insertError : null }),
+    }
+  }
+
+  return {
+    from,
+    storage: {
+      from: () => ({
+        upload: async () => ({
+          data: uploadError ? null : { path: 'capsule/photo.jpg' },
+          error: uploadError,
+        }),
+        getPublicUrl: () => ({ data: { publicUrl: 'https://example.test/photo.jpg' } }),
+      }),
+    },
+  }
+}
+
+const futureDate = '2999-12-31'
+const pastDate = '2000-01-01'
+
+function row(overrides: Partial<CapsuleRow> = {}): CapsuleRow {
+  return {
+    id: 1,
+    sender: 'テスト送信者',
+    recipient: null,
+    message: 'private capsule message',
+    photo_url: 'https://example.test/private.jpg',
+    unlock_date: futureDate,
+    created_at: '2026-08-23T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  getSupabaseMock.mockReset()
+  languageMock.value = 'ja'
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('Time Capsule parsers', () => {
+  const now = new Date('2026-08-23T12:00:00.000Z')
+
+  it('parses a remote capsule and hides locked content', () => {
+    expect(parseRemoteCapsule(row(), now)).toMatchObject({
+      id: 1,
+      unlockDate: futureDate,
+      isUnlocked: false,
+      message: '',
+      photoUrl: undefined,
+    })
+  })
+
+  it('keeps opened content and filters malformed records', () => {
+    expect(parseRemoteCapsule(row({ unlock_date: pastDate }), now)).toMatchObject({
+      isUnlocked: true,
+      message: 'private capsule message',
+      photoUrl: 'https://example.test/private.jpg',
+    })
+    expect(parseRemoteCapsule({ ...row(), unlock_date: '2026-02-30' }, now)).toBeNull()
+    expect(parseLocalCapsules({ invalid: true }, now)).toEqual([])
+    expect(parseLocalCapsules([{
+      id: 'local-date',
+      sender: '日付送信者',
+      message: '日付本文',
+      unlockDate: '2026-08-23',
+      createdAt: '2026-08-23T00:00:00.000Z',
+    }], now)[0]).toMatchObject({ isUnlocked: true, message: '日付本文' })
+  })
+})
+
+describe('TimeCapsule', () => {
+  it('hides unopened remote content and requests metadata only', async () => {
+    const selectCalls: string[] = []
+    getSupabaseMock.mockReturnValue(createSupabaseStub({ sealedRows: [row()], selectCalls }))
+    render(<TimeCapsule />)
+
+    expect(await screen.findByText(/^timeCapsuleLockedNotice:/)).toBeTruthy()
+    expect(selectCalls).toEqual([
+      'id,sender,recipient,message,photo_url,unlock_date,created_at',
+      'id,sender,recipient,unlock_date,created_at',
+    ])
+    expect(screen.queryByText('private capsule message')).toBeNull()
+    expect(screen.queryByRole('img')).toBeNull()
+  })
+
+  it('shows opened remote content', async () => {
+    getSupabaseMock.mockReturnValue(createSupabaseStub({ openedRows: [row({ unlock_date: pastDate })] }))
+    render(<TimeCapsule />)
+
+    expect(await screen.findByText(/private capsule message/)).toBeTruthy()
+  })
+
+  it('formats locked dates for English users', async () => {
+    languageMock.value = 'en'
+    getSupabaseMock.mockReturnValue(createSupabaseStub({ sealedRows: [row()] }))
+    render(<TimeCapsule />)
+
+    const expectedDate = new Date(2999, 11, 31).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    })
+    expect(await screen.findByText(`timeCapsuleLockedNotice:${expectedDate}`)).toBeTruthy()
+  })
+
+  it('uses valid local fallback data when remote fetch fails', async () => {
+    localStorage.setItem(
+      'local_time_capsules',
+      JSON.stringify([{
+        id: 'local-1',
+        sender: 'ローカル送信者',
+        message: 'local message',
+        unlockDate: pastDate,
+        createdAt: '2026-08-23T00:00:00.000Z',
+      }])
+    )
+    getSupabaseMock.mockReturnValue(createSupabaseStub({ selectError: new Error('offline') }))
+    render(<TimeCapsule />)
+
+    await screen.findByText('ローカル送信者')
+    expect(screen.getByText((content) => content.includes('local message'))).toBeTruthy()
+  })
+
+  it('ignores malformed local JSON without crashing', async () => {
+    localStorage.setItem('local_time_capsules', '{not-json')
+    getSupabaseMock.mockReturnValue(createSupabaseStub())
+    render(<TimeCapsule />)
+
+    expect(await screen.findByText('timeCapsuleEmptyDesc')).toBeTruthy()
+  })
+
+  it('falls back to local storage when insert fails', async () => {
+    getSupabaseMock.mockReturnValue(createSupabaseStub({ insertError: new Error('insert failed') }))
+    const { container } = render(<TimeCapsule />)
+    fireEvent.click(screen.getByRole('button', { name: 'sealNewCapsule' }))
+    fireEvent.change(screen.getByPlaceholderText('yourName'), { target: { value: '投稿者' } })
+    fireEvent.change(screen.getByPlaceholderText('capsuleMessagePlaceholder'), { target: { value: '保存する本文' } })
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement)
+
+    await waitFor(() => {
+      const saved = JSON.parse(localStorage.getItem('local_time_capsules') || '[]') as Array<{ sender: string; message: string }>
+      expect(saved[0]).toMatchObject({ sender: '投稿者', message: '保存する本文' })
+    })
+  })
+
+  it('reports upload failure without local fallback write', async () => {
+    getSupabaseMock.mockReturnValue(createSupabaseStub({ uploadError: new Error('upload failed') }))
+    const { container } = render(<TimeCapsule />)
+    fireEvent.click(screen.getByRole('button', { name: 'sealNewCapsule' }))
+    fireEvent.change(screen.getByPlaceholderText('yourName'), { target: { value: '投稿者' } })
+    fireEvent.change(screen.getByPlaceholderText('capsuleMessagePlaceholder'), { target: { value: '本文' } })
+    fireEvent.change(container.querySelector('input[type="file"]') as HTMLInputElement, {
+      target: { files: [new File(['image'], 'photo.jpg', { type: 'image/jpeg' })] },
+    })
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement)
+
+    expect(await screen.findByText('uploadFileFailed')).toBeTruthy()
+    expect(localStorage.getItem('local_time_capsules')).toBeNull()
+  })
+
+  it('cleans up the unlock interval on unmount', async () => {
+    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval')
+    getSupabaseMock.mockReturnValue(createSupabaseStub())
+    const { unmount } = render(<TimeCapsule />)
+    await screen.findByText('timeCapsuleEmptyDesc')
+    unmount()
+
+    expect(clearIntervalSpy).toHaveBeenCalled()
+  })
+})

--- a/__tests__/components/TimeCapsule.test.tsx
+++ b/__tests__/components/TimeCapsule.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import TimeCapsule, {
   parseLocalCapsules,
@@ -235,20 +235,28 @@ describe('TimeCapsule', () => {
   })
 
   it('falls back to local storage when insert fails', async () => {
-    getSupabaseMock.mockReturnValue(createSupabaseStub({ insertError: new Error('insert failed') }))
-    const { container } = render(<TimeCapsule />)
-    fireEvent.click(screen.getByRole('button', { name: 'sealNewCapsule' }))
-    fireEvent.change(screen.getByPlaceholderText('yourName'), { target: { value: '投稿者' } })
-    fireEvent.change(screen.getByPlaceholderText('capsuleMessagePlaceholder'), { target: { value: '保存する本文' } })
-    fireEvent.submit(container.querySelector('form') as HTMLFormElement)
+    vi.useFakeTimers()
+    try {
+      getSupabaseMock.mockReturnValue(createSupabaseStub({ insertError: new Error('insert failed') }))
+      const { container } = render(<TimeCapsule />)
+      fireEvent.click(screen.getByRole('button', { name: 'sealNewCapsule' }))
+      fireEvent.change(screen.getByPlaceholderText('yourName'), { target: { value: '投稿者' } })
+      fireEvent.change(screen.getByPlaceholderText('capsuleMessagePlaceholder'), { target: { value: '保存する本文' } })
 
-    await waitFor(() => {
+      await act(async () => {
+        fireEvent.submit(container.querySelector('form') as HTMLFormElement)
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+
       const saved = JSON.parse(localStorage.getItem('local_time_capsules') || '[]') as Array<{ sender: string; message: string }>
       expect(saved[0]).toMatchObject({ sender: '投稿者', message: '保存する本文' })
-    })
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 1200))
-    })
+      act(() => {
+        vi.advanceTimersByTime(1200)
+      })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('reports upload failure without local fallback write', async () => {

--- a/__tests__/components/TimeCapsule.test.tsx
+++ b/__tests__/components/TimeCapsule.test.tsx
@@ -353,6 +353,55 @@ describe('TimeCapsule', () => {
     expect(screen.getByText('genericError')).toBeTruthy()
   })
 
+  it('preserves a sealed capsule while the opened partition is unavailable', async () => {
+    let openedCalls = 0
+    let sealedCalls = 0
+    const capsuleId = 8
+    getSupabaseMock.mockReturnValue({
+      from: (table: string) => ({
+        select: () => ({
+          lte: () => ({
+            order: async () => {
+              openedCalls += 1
+              return { data: [], error: new Error('opened query failed') }
+            },
+          }),
+          gt: () => ({
+            order: async () => {
+              sealedCalls += 1
+              return sealedCalls === 1
+                ? { data: [row({ id: capsuleId, sender: '保持対象', message: '', photo_url: null })], error: null }
+                : { data: [], error: null }
+            },
+          }),
+        }),
+        insert: async () => ({ error: table === 'time_capsules' ? null : null }),
+      }),
+      storage: {
+        from: () => ({
+          upload: async () => ({ data: null, error: null }),
+          getPublicUrl: () => ({ data: { publicUrl: '' } }),
+        }),
+      },
+    } satisfies SupabaseStub)
+
+    render(<TimeCapsule />)
+    expect(await screen.findByText('保持対象')).toBeTruthy()
+    expect(await screen.findByText('genericError')).toBeTruthy()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'retry' }))
+    })
+
+    await vi.waitFor(() => {
+      expect(openedCalls).toBe(2)
+      expect(sealedCalls).toBe(2)
+    })
+    expect(screen.getByText('保持対象')).toBeTruthy()
+    expect(await screen.findByText('genericError')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'retry' })).toBeTruthy()
+  })
+
   it('clears an empty successful partition during refresh', async () => {
     let openedCalls = 0
     let sealedCalls = 0

--- a/__tests__/components/TimeCapsule.test.tsx
+++ b/__tests__/components/TimeCapsule.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import TimeCapsule, {
   parseLocalCapsules,
@@ -245,6 +245,9 @@ describe('TimeCapsule', () => {
     await waitFor(() => {
       const saved = JSON.parse(localStorage.getItem('local_time_capsules') || '[]') as Array<{ sender: string; message: string }>
       expect(saved[0]).toMatchObject({ sender: '投稿者', message: '保存する本文' })
+    })
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1200))
     })
   })
 

--- a/__tests__/components/TimeCapsule.test.tsx
+++ b/__tests__/components/TimeCapsule.test.tsx
@@ -256,6 +256,55 @@ describe('TimeCapsule', () => {
     expect(screen.getByRole('button', { name: 'retry' })).toBeTruthy()
   })
 
+  it('updates a successful partition while preserving the failed partition', async () => {
+    let openedCalls = 0
+    let sealedCalls = 0
+    getSupabaseMock.mockReturnValue({
+      from: (table: string) => ({
+        select: () => ({
+          lte: () => ({
+            order: async () => {
+              openedCalls += 1
+              return openedCalls === 1
+                ? { data: [], error: new Error('opened query failed') }
+                : { data: [row({ id: 2, sender: '新開封済み', unlock_date: pastDate })], error: null }
+            },
+          }),
+          gt: () => ({
+            order: async () => {
+              sealedCalls += 1
+              return sealedCalls === 1
+                ? { data: [row({ id: 3, sender: '封印済み', message: '', photo_url: null })], error: null }
+                : { data: [], error: new Error('sealed query failed') }
+            },
+          }),
+        }),
+        insert: async () => ({ error: table === 'time_capsules' ? null : null }),
+      }),
+      storage: {
+        from: () => ({
+          upload: async () => ({ data: null, error: null }),
+          getPublicUrl: () => ({ data: { publicUrl: '' } }),
+        }),
+      },
+    } satisfies SupabaseStub)
+
+    render(<TimeCapsule />)
+    expect(await screen.findByText('封印済み')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'retry' })).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'retry' }))
+
+    await vi.waitFor(() => {
+      expect(openedCalls).toBe(2)
+      expect(sealedCalls).toBe(2)
+    })
+    expect(await screen.findByText('新開封済み')).toBeTruthy()
+    expect(screen.queryByText('旧開封済み')).toBeNull()
+    expect(screen.getByText('封印済み')).toBeTruthy()
+    expect(screen.getByText('genericError')).toBeTruthy()
+  })
+
   it('preserves loaded capsules when a refresh query fails', async () => {
     let openedCalls = 0
     let sealedCalls = 0

--- a/__tests__/components/TimeCapsule.test.tsx
+++ b/__tests__/components/TimeCapsule.test.tsx
@@ -273,6 +273,69 @@ describe('TimeCapsule', () => {
     expect(localStorage.getItem('local_time_capsules')).toBeNull()
   })
 
+  it('retries a queued refresh after the active fetch completes', async () => {
+    let triggerRefresh: (() => void) | undefined
+    let resolveOpened!: (result: QueryResult) => void
+    let resolveSealed!: (result: QueryResult) => void
+    let openedCalls = 0
+    let sealedCalls = 0
+    const firstOpened = new Promise<QueryResult>((resolve) => {
+      resolveOpened = resolve
+    })
+    const firstSealed = new Promise<QueryResult>((resolve) => {
+      resolveSealed = resolve
+    })
+    const emptyResult: QueryResult = { data: [], error: null }
+
+    vi.spyOn(globalThis, 'setInterval').mockImplementation((callback) => {
+      triggerRefresh = callback as () => void
+      return 0 as unknown as ReturnType<typeof setInterval>
+    })
+    getSupabaseMock.mockReturnValue({
+      from: (table: string) => ({
+        select: () => ({
+          lte: () => ({
+            order: async () => {
+              openedCalls += 1
+              return openedCalls === 1 ? firstOpened : emptyResult
+            },
+          }),
+          gt: () => ({
+            order: async () => {
+              sealedCalls += 1
+              return sealedCalls === 1 ? firstSealed : emptyResult
+            },
+          }),
+        }),
+        insert: async () => ({ error: table === 'time_capsules' ? null : null }),
+      }),
+      storage: {
+        from: () => ({
+          upload: async () => ({ data: null, error: null }),
+          getPublicUrl: () => ({ data: { publicUrl: '' } }),
+        }),
+      },
+    } satisfies SupabaseStub)
+
+    render(<TimeCapsule />)
+    act(() => {
+      triggerRefresh?.()
+    })
+    expect(openedCalls).toBe(1)
+    expect(sealedCalls).toBe(1)
+
+    await act(async () => {
+      resolveOpened(emptyResult)
+      resolveSealed(emptyResult)
+      await Promise.all([firstOpened, firstSealed])
+    })
+
+    await vi.waitFor(() => {
+      expect(openedCalls).toBe(2)
+      expect(sealedCalls).toBe(2)
+    })
+  })
+
   it('cleans up the refresh interval on unmount', async () => {
     const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval')
     getSupabaseMock.mockReturnValue(createSupabaseStub())

--- a/__tests__/components/TimeCapsule.test.tsx
+++ b/__tests__/components/TimeCapsule.test.tsx
@@ -243,10 +243,9 @@ describe('TimeCapsule', () => {
       fireEvent.change(screen.getByPlaceholderText('yourName'), { target: { value: '投稿者' } })
       fireEvent.change(screen.getByPlaceholderText('capsuleMessagePlaceholder'), { target: { value: '保存する本文' } })
 
-      await act(async () => {
-        fireEvent.submit(container.querySelector('form') as HTMLFormElement)
-        await Promise.resolve()
-        await Promise.resolve()
+      fireEvent.submit(container.querySelector('form') as HTMLFormElement)
+      await vi.waitFor(() => {
+        expect(screen.getByText('sealedSuccess')).toBeTruthy()
       })
 
       const saved = JSON.parse(localStorage.getItem('local_time_capsules') || '[]') as Array<{ sender: string; message: string }>

--- a/__tests__/components/TimeCapsule.test.tsx
+++ b/__tests__/components/TimeCapsule.test.tsx
@@ -166,10 +166,13 @@ describe('TimeCapsule', () => {
     render(<TimeCapsule />)
 
     expect(await screen.findByText(/^timeCapsuleLockedNotice:/)).toBeTruthy()
-    expect(selectCalls).toEqual([
-      'id,sender,recipient,message,photo_url,unlock_date,created_at',
-      'id,sender,recipient,unlock_date,created_at',
-    ])
+    expect(selectCalls).toHaveLength(2)
+    const openedSelect = selectCalls.find((columns) => columns.includes('message'))
+    const sealedSelect = selectCalls.find((columns) => !columns.includes('message'))
+    expect(openedSelect).toContain('message')
+    expect(openedSelect).toContain('photo_url')
+    expect(sealedSelect).not.toContain('message')
+    expect(sealedSelect).not.toContain('photo_url')
     expect(screen.queryByText('private capsule message')).toBeNull()
     expect(screen.queryByRole('img')).toBeNull()
   })

--- a/__tests__/components/TimeCapsule.test.tsx
+++ b/__tests__/components/TimeCapsule.test.tsx
@@ -184,6 +184,64 @@ describe('TimeCapsule', () => {
     expect(await screen.findByText(/private capsule message/)).toBeTruthy()
   })
 
+  it('keeps loaded capsules visible during a refresh', async () => {
+    let resolveOpened!: (result: QueryResult) => void
+    let resolveSealed!: (result: QueryResult) => void
+    let openedCalls = 0
+    let sealedCalls = 0
+    const pendingOpened = new Promise<QueryResult>((resolve) => {
+      resolveOpened = resolve
+    })
+    const pendingSealed = new Promise<QueryResult>((resolve) => {
+      resolveSealed = resolve
+    })
+    const openedResult: QueryResult = { data: [row({ unlock_date: pastDate })], error: null }
+    const sealedError = new Error('sealed query failed')
+    const emptyResult: QueryResult = { data: [], error: null }
+
+    getSupabaseMock.mockReturnValue({
+      from: (table: string) => ({
+        select: () => ({
+          lte: () => ({
+            order: async () => {
+              openedCalls += 1
+              return openedCalls === 1 ? openedResult : pendingOpened
+            },
+          }),
+          gt: () => ({
+            order: async () => {
+              sealedCalls += 1
+              return sealedCalls === 1 ? { data: [], error: sealedError } : pendingSealed
+            },
+          }),
+        }),
+        insert: async () => ({ error: table === 'time_capsules' ? null : null }),
+      }),
+      storage: {
+        from: () => ({
+          upload: async () => ({ data: null, error: null }),
+          getPublicUrl: () => ({ data: { publicUrl: '' } }),
+        }),
+      },
+    } satisfies SupabaseStub)
+
+    render(<TimeCapsule />)
+    expect(await screen.findByText(/private capsule message/)).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'retry' }))
+    await vi.waitFor(() => {
+      expect(openedCalls).toBe(2)
+      expect(sealedCalls).toBe(2)
+    })
+    expect(screen.getByText(/private capsule message/)).toBeTruthy()
+    expect(screen.queryByText('loading')).toBeNull()
+
+    await act(async () => {
+      resolveOpened(emptyResult)
+      resolveSealed(emptyResult)
+      await Promise.all([pendingOpened, pendingSealed])
+    })
+  })
+
   it('shows degraded retry feedback when one query fails', async () => {
     const selectCalls: string[] = []
     getSupabaseMock.mockReturnValue(createSupabaseStub({

--- a/__tests__/components/TimeCapsule.test.tsx
+++ b/__tests__/components/TimeCapsule.test.tsx
@@ -58,6 +58,8 @@ function createSupabaseStub({
   openedRows = [],
   sealedRows = [],
   selectError = null,
+  openedError = selectError,
+  sealedError = selectError,
   insertError = null,
   uploadError = null,
   selectCalls = [],
@@ -65,14 +67,16 @@ function createSupabaseStub({
   openedRows?: CapsuleRow[]
   sealedRows?: CapsuleRow[]
   selectError?: Error | null
+  openedError?: Error | null
+  sealedError?: Error | null
   insertError?: Error | null
   uploadError?: Error | null
   selectCalls?: string[]
 } = {}): SupabaseStub {
   const from = (table: string) => {
     const query = {
-      lte: () => ({ order: async () => ({ data: openedRows, error: selectError }) }),
-      gt: () => ({ order: async () => ({ data: sealedRows, error: selectError }) }),
+      lte: () => ({ order: async () => ({ data: openedRows, error: openedError }) }),
+      gt: () => ({ order: async () => ({ data: sealedRows, error: sealedError }) }),
     }
 
     return {
@@ -175,6 +179,20 @@ describe('TimeCapsule', () => {
     render(<TimeCapsule />)
 
     expect(await screen.findByText(/private capsule message/)).toBeTruthy()
+  })
+
+  it('shows degraded retry feedback when one query fails', async () => {
+    const selectCalls: string[] = []
+    getSupabaseMock.mockReturnValue(createSupabaseStub({
+      openedRows: [row({ unlock_date: pastDate })],
+      sealedError: new Error('sealed query failed'),
+      selectCalls,
+    }))
+    render(<TimeCapsule />)
+
+    expect(await screen.findByText(/private capsule message/)).toBeTruthy()
+    expect(screen.getByText('genericError')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'retry' })).toBeTruthy()
   })
 
   it('formats locked dates for English users', async () => {

--- a/__tests__/components/TimeCapsule.test.tsx
+++ b/__tests__/components/TimeCapsule.test.tsx
@@ -305,7 +305,7 @@ describe('TimeCapsule', () => {
     expect(screen.getByText('genericError')).toBeTruthy()
   })
 
-  it('preserves loaded capsules when a refresh query fails', async () => {
+  it('clears an empty successful partition during refresh', async () => {
     let openedCalls = 0
     let sealedCalls = 0
     getSupabaseMock.mockReturnValue({
@@ -347,7 +347,7 @@ describe('TimeCapsule', () => {
       expect(openedCalls).toBe(2)
       expect(sealedCalls).toBe(2)
     })
-    expect(screen.getByText('開封済み')).toBeTruthy()
+    expect(screen.queryByText('開封済み')).toBeNull()
     expect(await screen.findByText('genericError')).toBeTruthy()
   })
 

--- a/__tests__/components/TimeCapsule.test.tsx
+++ b/__tests__/components/TimeCapsule.test.tsx
@@ -305,6 +305,54 @@ describe('TimeCapsule', () => {
     expect(screen.getByText('genericError')).toBeTruthy()
   })
 
+  it('deduplicates a capsule that moves from sealed to opened', async () => {
+    let openedCalls = 0
+    let sealedCalls = 0
+    const capsuleId = 7
+    getSupabaseMock.mockReturnValue({
+      from: (table: string) => ({
+        select: () => ({
+          lte: () => ({
+            order: async () => {
+              openedCalls += 1
+              return openedCalls === 1
+                ? { data: [], error: new Error('opened query failed') }
+                : { data: [row({ id: capsuleId, sender: '開封済み', unlock_date: pastDate })], error: null }
+            },
+          }),
+          gt: () => ({
+            order: async () => {
+              sealedCalls += 1
+              return sealedCalls === 1
+                ? { data: [row({ id: capsuleId, sender: '封印済み', message: '', photo_url: null })], error: null }
+                : { data: [], error: new Error('sealed query failed') }
+            },
+          }),
+        }),
+        insert: async () => ({ error: table === 'time_capsules' ? null : null }),
+      }),
+      storage: {
+        from: () => ({
+          upload: async () => ({ data: null, error: null }),
+          getPublicUrl: () => ({ data: { publicUrl: '' } }),
+        }),
+      },
+    } satisfies SupabaseStub)
+
+    render(<TimeCapsule />)
+    expect(await screen.findByText('封印済み')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'retry' }))
+
+    await vi.waitFor(() => {
+      expect(openedCalls).toBe(2)
+      expect(sealedCalls).toBe(2)
+    })
+    expect(await screen.findByText('開封済み')).toBeTruthy()
+    expect(screen.queryByText('封印済み')).toBeNull()
+    expect(screen.getByText((content) => content.includes('private capsule message'))).toBeTruthy()
+    expect(screen.getByText('genericError')).toBeTruthy()
+  })
+
   it('clears an empty successful partition during refresh', async () => {
     let openedCalls = 0
     let sealedCalls = 0

--- a/components/community/TimeCapsule.tsx
+++ b/components/community/TimeCapsule.tsx
@@ -5,7 +5,7 @@ import { getSupabase } from '@/lib/supabase/client'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { Icon } from '@/components/ui/Icon'
 
-interface CapsuleItem {
+export interface CapsuleItem {
   id: string | number
   sender: string
   recipient?: string
@@ -16,20 +16,102 @@ interface CapsuleItem {
   isUnlocked: boolean
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function isValidDateValue(value: string): boolean {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    const [year, month, day] = value.split('-').map(Number)
+    const date = new Date(year, month - 1, day)
+    return date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day
+  }
+
+  return !Number.isNaN(new Date(value).getTime())
+}
+
+function formatLocalDate(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
 // ローカル日付文字列（YYYY-MM-DD）をローカル時間 00:00:00 の Date オブジェクトに変換
 function parseLocalDate(dateStr: string): Date {
   const parts = dateStr.split('-').map(Number)
-  if (parts.length === 3) {
+  if (parts.length === 3 && /^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
     return new Date(parts[0], parts[1] - 1, parts[2], 0, 0, 0)
   }
   return new Date(dateStr)
 }
 
+function parseCapsuleItem(
+  value: unknown,
+  now: Date,
+  format: 'remote' | 'local'
+): CapsuleItem | null {
+  if (!isRecord(value)) return null
+
+  const id = value.id
+  const sender = value.sender
+  const message = value.message
+  const unlockDate = format === 'remote' ? value.unlock_date : value.unlockDate
+  const createdAt = format === 'remote' ? value.created_at : value.createdAt
+  const recipient = value.recipient
+  const photoUrl = format === 'remote' ? value.photo_url : value.photoUrl
+
+  if (
+    !(typeof id === 'string' || typeof id === 'number') ||
+    typeof sender !== 'string' ||
+    (typeof message !== 'string' && message !== null && message !== undefined) ||
+    typeof unlockDate !== 'string' ||
+    typeof createdAt !== 'string' ||
+    !isValidDateValue(unlockDate) ||
+    Number.isNaN(new Date(createdAt).getTime()) ||
+    (recipient !== undefined && recipient !== null && typeof recipient !== 'string') ||
+    (photoUrl !== undefined && photoUrl !== null && typeof photoUrl !== 'string')
+  ) {
+    return null
+  }
+
+  const isUnlocked = parseLocalDate(unlockDate) <= now
+  if (
+    (format === 'local' && typeof message !== 'string') ||
+    (format === 'remote' && isUnlocked && typeof message !== 'string')
+  ) {
+    return null
+  }
+
+  return {
+    id,
+    sender,
+    recipient: recipient || undefined,
+    message: isUnlocked && typeof message === 'string' ? message : '',
+    photoUrl: isUnlocked && typeof photoUrl === 'string' ? photoUrl : undefined,
+    unlockDate,
+    createdAt,
+    isUnlocked,
+  }
+}
+
+export function parseRemoteCapsule(value: unknown, now = new Date()): CapsuleItem | null {
+  return parseCapsuleItem(value, now, 'remote')
+}
+
+export function parseLocalCapsules(value: unknown, now = new Date()): CapsuleItem[] {
+  if (!Array.isArray(value)) return []
+  return value
+    .map((item) => parseCapsuleItem(item, now, 'local'))
+    .filter((item): item is CapsuleItem => item !== null)
+}
+
 // 未来の記念日に届くタイムカプセルコンポーネント
-export function TimeCapsule({ onClose }: { onClose?: () => void }) {
+export function TimeCapsule() {
   const { t, language } = useLanguage()
   const [capsules, setCapsules] = useState<CapsuleItem[]>([])
   const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState(false)
   const [activeTab, setActiveTab] = useState<'view' | 'create'>('view')
 
   // 作成フォームの状態
@@ -49,89 +131,87 @@ export function TimeCapsule({ onClose }: { onClose?: () => void }) {
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [submitSuccess, setSubmitSuccess] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const isMountedRef = useRef(true)
+  const refreshInFlightRef = useRef(false)
 
   // タイムカプセル一覧の取得およびローカル保存データの統合
   const fetchCapsules = async () => {
+    if (!isMountedRef.current || refreshInFlightRef.current) return
+    refreshInFlightRef.current = true
     setLoading(true)
+    setLoadError(false)
     try {
       const supabase = getSupabase()
       const now = new Date()
+      const today = formatLocalDate(now)
 
-      const { data, error } = await supabase
+      const openedQuery = supabase
         .from('time_capsules')
-        .select('*')
+        .select('id,sender,recipient,message,photo_url,unlock_date,created_at')
+        .lte('unlock_date', today)
         .order('unlock_date', { ascending: true })
+      const sealedQuery = supabase
+        .from('time_capsules')
+        .select('id,sender,recipient,unlock_date,created_at')
+        .gt('unlock_date', today)
+        .order('unlock_date', { ascending: true })
+      const [openedResult, sealedResult] = await Promise.all([openedQuery, sealedQuery])
+
+      const openedData = openedResult.data || []
+      const sealedData = sealedResult.data || []
+      const data = [
+        ...openedData.map((capsule) => ({ ...capsule, message: capsule.message, photo_url: capsule.photo_url })),
+        ...sealedData.map((capsule) => ({ ...capsule, message: null, photo_url: null })),
+      ]
+      const queryError = openedResult.error || sealedResult.error
 
       // ローカルストレージフォールバックデータの取得
       let localCapsules: CapsuleItem[] = []
       try {
         const localSaved = localStorage.getItem('local_time_capsules')
         if (localSaved) {
-          localCapsules = JSON.parse(localSaved) as CapsuleItem[]
+          localCapsules = parseLocalCapsules(JSON.parse(localSaved), now)
         }
       } catch {
         localCapsules = []
       }
 
-      let remoteCapsules: CapsuleItem[] = []
-      if (!error && data) {
-        remoteCapsules = data.map((c: any) => {
-          const unlockTime = parseLocalDate(c.unlock_date)
-          const isUnlocked = unlockTime <= now
-          return {
-            id: c.id,
-            sender: c.sender,
-            recipient: c.recipient,
-            // 未開封時は内容を秘匿化
-            message: isUnlocked ? c.message : '',
-            photoUrl: isUnlocked ? c.photo_url : undefined,
-            unlockDate: c.unlock_date,
-            createdAt: c.created_at,
-            isUnlocked,
-          }
-        })
-      }
+      const remoteCapsules = data
+        .map((capsule) => parseRemoteCapsule(capsule, now))
+        .filter((capsule): capsule is CapsuleItem => capsule !== null)
 
       // リモートとローカルの統合（ID重複を排除）
       const remoteIds = new Set(remoteCapsules.map((c) => String(c.id)))
-      const unmergedLocal = localCapsules
-        .filter((c) => !remoteIds.has(String(c.id)))
-        .map((c) => {
-          const unlockTime = parseLocalDate(c.unlockDate)
-          const isUnlocked = unlockTime <= now
-          return {
-            ...c,
-            isUnlocked,
-            message: isUnlocked ? c.message : '',
-            photoUrl: isUnlocked ? c.photoUrl : undefined,
-          }
-        })
+      const unmergedLocal = localCapsules.filter((c) => !remoteIds.has(String(c.id)))
 
       const combined = [...remoteCapsules, ...unmergedLocal].sort(
         (a, b) => parseLocalDate(a.unlockDate).getTime() - parseLocalDate(b.unlockDate).getTime()
       )
 
+      if (!isMountedRef.current) return
+      setLoadError(Boolean(queryError) && combined.length === 0)
       setCapsules(combined)
     } catch {
+      if (!isMountedRef.current) return
+      setLoadError(true)
       setCapsules([])
     } finally {
-      setLoading(false)
+      refreshInFlightRef.current = false
+      if (isMountedRef.current) setLoading(false)
     }
   }
 
   useEffect(() => {
-    fetchCapsules()
-    // 定期的に開封状態を再計算
+    isMountedRef.current = true
+    void fetchCapsules()
     const interval = setInterval(() => {
-      setCapsules((prev) =>
-        prev.map((c) => ({
-          ...c,
-          isUnlocked: parseLocalDate(c.unlockDate) <= new Date(),
-        }))
-      )
+      void fetchCapsules()
     }, 30000)
 
-    return () => clearInterval(interval)
+    return () => {
+      isMountedRef.current = false
+      clearInterval(interval)
+    }
   }, [])
 
   // タイムカプセルの封印処理
@@ -243,6 +323,17 @@ export function TimeCapsule({ onClose }: { onClose?: () => void }) {
             <div className="flex flex-col items-center justify-center py-12 gap-3">
               <div className="w-8 h-8 border-3 border-[#D4B08C]/30 border-t-[#854D27] rounded-full animate-spin" />
               <span className="text-xs text-[#854D27]/80">{t('loading')}</span>
+            </div>
+          ) : loadError && capsules.length === 0 ? (
+            <div className="text-center py-12 bg-[#FFF9F3] border-2 border-dashed border-red-200 rounded-2xl p-6">
+              <p className="text-xs text-red-600 mb-4">{t('genericError')}</p>
+              <button
+                type="button"
+                onClick={fetchCapsules}
+                className="px-4 py-2 rounded-xl bg-[#854D27] text-[#FFF9F3] text-xs font-bold hover:brightness-110 transition-all cursor-pointer"
+              >
+                {t('retry')}
+              </button>
             </div>
           ) : capsules.length > 0 ? (
             <div className="space-y-4 max-h-[55vh] overflow-y-auto pr-1">

--- a/components/community/TimeCapsule.tsx
+++ b/components/community/TimeCapsule.tsx
@@ -133,6 +133,8 @@ export function TimeCapsule() {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const isMountedRef = useRef(true)
   const hasLoadedCapsulesRef = useRef(false)
+  const openedCapsulesRef = useRef<CapsuleItem[]>([])
+  const sealedCapsulesRef = useRef<CapsuleItem[]>([])
   const refreshInFlightRef = useRef(false)
   const refreshQueuedRef = useRef(false)
 
@@ -165,10 +167,19 @@ export function TimeCapsule() {
 
       const openedData = openedResult.data || []
       const sealedData = sealedResult.data || []
-      const data = [
-        ...openedData.map((capsule) => ({ ...capsule, message: capsule.message, photo_url: capsule.photo_url })),
-        ...sealedData.map((capsule) => ({ ...capsule, message: null, photo_url: null })),
-      ]
+      const openedCapsules = openedData
+        .map((capsule) => parseRemoteCapsule({ ...capsule, message: capsule.message, photo_url: capsule.photo_url }, now))
+        .filter((capsule): capsule is CapsuleItem => capsule !== null)
+      const sealedCapsules = sealedData
+        .map((capsule) => parseRemoteCapsule({ ...capsule, message: null, photo_url: null }, now))
+        .filter((capsule): capsule is CapsuleItem => capsule !== null)
+      if (!openedResult.error && (openedCapsules.length > 0 || !hasLoadedCapsulesRef.current)) {
+        openedCapsulesRef.current = openedCapsules
+      }
+      if (!sealedResult.error && (sealedCapsules.length > 0 || !hasLoadedCapsulesRef.current)) {
+        sealedCapsulesRef.current = sealedCapsules
+      }
+      const remoteCapsules = [...openedCapsulesRef.current, ...sealedCapsulesRef.current]
       const queryError = openedResult.error || sealedResult.error
 
       // ローカルストレージフォールバックデータの取得
@@ -182,10 +193,6 @@ export function TimeCapsule() {
         localCapsules = []
       }
 
-      const remoteCapsules = data
-        .map((capsule) => parseRemoteCapsule(capsule, now))
-        .filter((capsule): capsule is CapsuleItem => capsule !== null)
-
       // リモートとローカルの統合（ID重複を排除）
       const remoteIds = new Set(remoteCapsules.map((c) => String(c.id)))
       const unmergedLocal = localCapsules.filter((c) => !remoteIds.has(String(c.id)))
@@ -196,9 +203,7 @@ export function TimeCapsule() {
 
       if (!isMountedRef.current) return
       setLoadError(Boolean(queryError))
-      if (!queryError || !hasLoadedCapsulesRef.current) {
-        setCapsules(combined)
-      }
+      setCapsules(combined)
       hasLoadedCapsulesRef.current = true
     } catch {
       if (!isMountedRef.current) return

--- a/components/community/TimeCapsule.tsx
+++ b/components/community/TimeCapsule.tsx
@@ -179,7 +179,16 @@ export function TimeCapsule() {
       if (!sealedResult.error) {
         sealedCapsulesRef.current = sealedCapsules
       }
-      const remoteCapsules = [...openedCapsulesRef.current, ...sealedCapsulesRef.current]
+      const remoteCapsules = Array.from(
+        [...openedCapsulesRef.current, ...sealedCapsulesRef.current].reduce(
+          (capsulesById, capsule) => {
+            const id = String(capsule.id)
+            if (!capsulesById.has(id)) capsulesById.set(id, capsule)
+            return capsulesById
+          },
+          new Map<string, CapsuleItem>()
+        ).values()
+      )
       const queryError = openedResult.error || sealedResult.error
 
       // ローカルストレージフォールバックデータの取得

--- a/components/community/TimeCapsule.tsx
+++ b/components/community/TimeCapsule.tsx
@@ -173,10 +173,10 @@ export function TimeCapsule() {
       const sealedCapsules = sealedData
         .map((capsule) => parseRemoteCapsule({ ...capsule, message: null, photo_url: null }, now))
         .filter((capsule): capsule is CapsuleItem => capsule !== null)
-      if (!openedResult.error && (openedCapsules.length > 0 || !hasLoadedCapsulesRef.current)) {
+      if (!openedResult.error) {
         openedCapsulesRef.current = openedCapsules
       }
-      if (!sealedResult.error && (sealedCapsules.length > 0 || !hasLoadedCapsulesRef.current)) {
+      if (!sealedResult.error) {
         sealedCapsulesRef.current = sealedCapsules
       }
       const remoteCapsules = [...openedCapsulesRef.current, ...sealedCapsulesRef.current]

--- a/components/community/TimeCapsule.tsx
+++ b/components/community/TimeCapsule.tsx
@@ -133,10 +133,15 @@ export function TimeCapsule() {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const isMountedRef = useRef(true)
   const refreshInFlightRef = useRef(false)
+  const refreshQueuedRef = useRef(false)
 
   // タイムカプセル一覧の取得およびローカル保存データの統合
   const fetchCapsules = async () => {
-    if (!isMountedRef.current || refreshInFlightRef.current) return
+    if (!isMountedRef.current) return
+    if (refreshInFlightRef.current) {
+      refreshQueuedRef.current = true
+      return
+    }
     refreshInFlightRef.current = true
     setLoading(true)
     setLoadError(false)
@@ -197,7 +202,12 @@ export function TimeCapsule() {
       setCapsules([])
     } finally {
       refreshInFlightRef.current = false
-      if (isMountedRef.current) setLoading(false)
+      if (!isMountedRef.current) return
+      setLoading(false)
+      if (refreshQueuedRef.current) {
+        refreshQueuedRef.current = false
+        void fetchCapsules()
+      }
     }
   }
 

--- a/components/community/TimeCapsule.tsx
+++ b/components/community/TimeCapsule.tsx
@@ -189,7 +189,7 @@ export function TimeCapsule() {
       )
 
       if (!isMountedRef.current) return
-      setLoadError(Boolean(queryError) && combined.length === 0)
+      setLoadError(Boolean(queryError))
       setCapsules(combined)
     } catch {
       if (!isMountedRef.current) return
@@ -336,7 +336,16 @@ export function TimeCapsule() {
               </button>
             </div>
           ) : capsules.length > 0 ? (
-            <div className="space-y-4 max-h-[55vh] overflow-y-auto pr-1">
+            <div>
+              {loadError && (
+                <div className="mb-3 rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+                  <span>{t('genericError')}</span>{' '}
+                  <button type="button" onClick={fetchCapsules} className="font-bold underline cursor-pointer">
+                    {t('retry')}
+                  </button>
+                </div>
+              )}
+              <div className="space-y-4 max-h-[55vh] overflow-y-auto pr-1">
               {capsules.map((capsule) => (
                 <div
                   key={capsule.id}
@@ -384,7 +393,8 @@ export function TimeCapsule() {
                     </p>
                   )}
                 </div>
-              ))}
+                ))}
+              </div>
             </div>
           ) : (
             <div className="text-center py-12 bg-[#FFF9F3] border-2 border-dashed border-[#D4B08C] rounded-2xl p-6">
@@ -447,7 +457,7 @@ export function TimeCapsule() {
               type="date"
               required
               value={unlockDate}
-              min={new Date().toISOString().slice(0, 10)}
+              min={formatLocalDate(new Date())}
               onChange={(e) => setUnlockDate(e.target.value)}
               className="w-full px-3 py-2 rounded-xl bg-white border border-[#D4B08C] text-xs text-[#854D27] focus:outline-none focus:ring-2 focus:ring-[#854D27]"
             />

--- a/components/community/TimeCapsule.tsx
+++ b/components/community/TimeCapsule.tsx
@@ -196,7 +196,9 @@ export function TimeCapsule() {
 
       if (!isMountedRef.current) return
       setLoadError(Boolean(queryError))
-      setCapsules(combined)
+      if (!queryError || !hasLoadedCapsulesRef.current) {
+        setCapsules(combined)
+      }
       hasLoadedCapsulesRef.current = true
     } catch {
       if (!isMountedRef.current) return

--- a/components/community/TimeCapsule.tsx
+++ b/components/community/TimeCapsule.tsx
@@ -176,7 +176,7 @@ export function TimeCapsule() {
       if (!openedResult.error) {
         openedCapsulesRef.current = openedCapsules
       }
-      if (!sealedResult.error) {
+      if (!sealedResult.error && (!openedResult.error || !hasLoadedCapsulesRef.current)) {
         sealedCapsulesRef.current = sealedCapsules
       }
       const remoteCapsules = Array.from(

--- a/components/community/TimeCapsule.tsx
+++ b/components/community/TimeCapsule.tsx
@@ -132,6 +132,7 @@ export function TimeCapsule() {
   const [submitSuccess, setSubmitSuccess] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const isMountedRef = useRef(true)
+  const hasLoadedCapsulesRef = useRef(false)
   const refreshInFlightRef = useRef(false)
   const refreshQueuedRef = useRef(false)
 
@@ -143,7 +144,7 @@ export function TimeCapsule() {
       return
     }
     refreshInFlightRef.current = true
-    setLoading(true)
+    if (!hasLoadedCapsulesRef.current) setLoading(true)
     setLoadError(false)
     try {
       const supabase = getSupabase()
@@ -196,10 +197,14 @@ export function TimeCapsule() {
       if (!isMountedRef.current) return
       setLoadError(Boolean(queryError))
       setCapsules(combined)
+      hasLoadedCapsulesRef.current = true
     } catch {
       if (!isMountedRef.current) return
       setLoadError(true)
-      setCapsules([])
+      if (!hasLoadedCapsulesRef.current) {
+        setCapsules([])
+        hasLoadedCapsulesRef.current = true
+      }
     } finally {
       refreshInFlightRef.current = false
       if (!isMountedRef.current) return

--- a/components/ui/ModalManager.tsx
+++ b/components/ui/ModalManager.tsx
@@ -141,7 +141,7 @@ export function ModalManager() {
     },
     timeCapsule: {
       title: t('timeCapsuleTitle'),
-      content: <TimeCapsule onClose={closeModal} />,
+      content: <TimeCapsule />,
       size: 'md' as const,
     },
   }


### PR DESCRIPTION
## 概要
Time Capsule の local hardening を完了する PR です。typed parsing、未開封データを取得しない query projection、local date 境界、refresh race 防止、partial query の degraded error/retry、partition transition の重複・一時的な表示消失防止、JA/EN と境界テストを含みます。production schema、RLS、Storage policy、データは変更しません。

## Implementation checklist
- [x] #33 実装前の品質ゲート baseline を固定する
- [x] #35 Time Capsule の型安全な parsing を整備する
- [x] #36 Time Capsule の境界ケースを個別検証する

## Verification checklist
- [x] Self-review と対象範囲の確認を完了する
- [x] targeted tests、全体 tests、build、diff check を実行する
- [x] desktop/mobile の主要状態と accessibility を確認する
- [x] secret、private config、未開封本文・画像を今回の diff に含めないことを確認する
- [x] production migration、schema、RLS、Storage policy を変更していないことを確認する
- [x] Issue #33、#35、#36 の checklist と verification evidence を同期する
- [x] GitHub Actions verify、Greptile Review、Vercel Preview Comments、Cubic review を確認する
- [x] `1.0.0` との merge conflict を解消し、GitHub の mergeable state が clean であることを確認する

## 検証結果
- `npx vitest run __tests__/components/TimeCapsule.test.tsx`: 17/17 pass
- `npm test`: 31 files / 227 tests pass
- `npm run build`: pass
- changed-file lint: 0 errors、既存 warning 2件
- `git diff --check`: pass
- browser: opened/sealed、JA/EN、retry/error、mobile 390x844、network no-write を確認
- latest commit `c5d4026`: `1.0.0` を merge し、Time Capsule hardening を保持して競合を解消
- GitHub Actions verify: pass
- Greptile Review: pass
- Vercel Preview Comments: pass
- Cubic review: pass
- GitHub mergeable state: clean

## 既知の制約
- global lint と `npx tsc --noEmit` には、本 PR の変更前から存在する対象外テストの失敗があります。
- #31 と #32 の production schema、ownership、RLS、Storage privacy は、この local hardening のスコープ外です。
- production に `public.time_capsules` は存在せず、`time-capsules` Storage は public かつ anon-readable/writable です。identity、ownership、RLS、Storage privacy の決定は #47 で扱います。承認前の production change は実行しません。

## References
Refs #31
Refs #32
Refs #33
Refs #35
Refs #36
Refs #47