### PR TITLE
Reminder と Time Capsule の lifecycle 契約を整える

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,9 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      - run: npx playwright install --with-deps chromium
       - run: npm run lint
       - run: npm run typecheck
       - run: npm test
+      - run: npm run test:e2e
       - run: npm run build

--- a/README.en.md
+++ b/README.en.md
@@ -1,6 +1,6 @@
 # Omoide
 
-> **Omoide Bako**  
+> **Omoide Bako**
 > An interactive celebration and keepsake space for birthdays, cherished memories, and friends.
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Omoide
 
-> **Omoide Bako（想い出箱）**  
+> **Omoide Bako（想い出箱）**
 > 大切な人の誕生日と、みんなの思い出をひとつの場所に。
 
 <p align="center">

--- a/__tests__/api/time-capsules-access-route.test.ts
+++ b/__tests__/api/time-capsules-access-route.test.ts
@@ -6,6 +6,7 @@ const server = vi.hoisted(() => ({
   findByAccessCode: vi.fn(),
   getAccessAttemptBucketFingerprint: vi.fn(),
   parseAccessCode: vi.fn(),
+  recordFirstOpen: vi.fn(),
   serializeCapsule: vi.fn(),
 }))
 
@@ -41,6 +42,7 @@ beforeEach(() => {
   server.parseAccessCode.mockReturnValue('123456')
   server.getAccessAttemptBucketFingerprint.mockReturnValue('a'.repeat(64))
   server.findByAccessCode.mockResolvedValue({ client: {}, row: { id: 1 } })
+  server.recordFirstOpen.mockResolvedValue(true)
   server.serializeCapsule.mockResolvedValue({ id: 1, isUnlocked: false })
   server.errorResponse.mockImplementation((error: { code?: string; status?: number }) =>
     Response.json({ error: { code: error.code ?? 'internal_error' } }, { status: error.status ?? 500 })
@@ -73,6 +75,17 @@ describe('POST /api/time-capsules/access', () => {
 
     expect(server.getAccessAttemptBucketFingerprint).toHaveBeenCalledWith(firstRequest)
     expect(server.findByAccessCode).toHaveBeenCalledWith('123456', 'a'.repeat(64))
+  })
+
+  it('returns the unlocked capsule when first-open persistence fails', async () => {
+    const data = { id: 1, isUnlocked: true, message: '本文' }
+    server.serializeCapsule.mockResolvedValue(data)
+    server.recordFirstOpen.mockRejectedValue(new Error('database unavailable'))
+
+    const response = await POST(request({ accessCode: '123456' }))
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ data })
   })
 
   it('returns invalid_input for malformed JSON', async () => {

--- a/__tests__/api/time-capsules-invite-access-route.test.ts
+++ b/__tests__/api/time-capsules-invite-access-route.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const server = vi.hoisted(() => ({
+  errorResponse: vi.fn(),
+  findByInviteToken: vi.fn(),
+  parseId: vi.fn(),
+  parseInviteToken: vi.fn(),
+  recordFirstOpen: vi.fn(),
+  serializeCapsule: vi.fn(),
+}))
+
+vi.mock('@/lib/time-capsule/server', () => ({
+  TimeCapsuleError: class TimeCapsuleError extends Error {
+    constructor(readonly code: string, readonly status: number, message: string) {
+      super(message)
+    }
+  },
+  ...server,
+}))
+
+import { POST } from '@/app/api/time-capsules/[id]/access/route'
+
+function request(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/time-capsules/1/access', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  server.parseId.mockReturnValue(1)
+  server.parseInviteToken.mockReturnValue('a'.repeat(32))
+  server.findByInviteToken.mockResolvedValue({ client: {}, row: { id: 1 } })
+  server.recordFirstOpen.mockResolvedValue(true)
+  server.serializeCapsule.mockResolvedValue({ id: 1, isUnlocked: false })
+  server.errorResponse.mockImplementation((error: { code?: string; status?: number }) =>
+    Response.json({ error: { code: error.code ?? 'internal_error' } }, { status: error.status ?? 500 })
+  )
+})
+
+describe('POST /api/time-capsules/[id]/access', () => {
+  it('returns the unlocked capsule when first-open persistence fails', async () => {
+    const data = { id: 1, isUnlocked: true, message: '本文' }
+    server.serializeCapsule.mockResolvedValue(data)
+    server.recordFirstOpen.mockRejectedValue(new Error('database unavailable'))
+
+    const response = await POST(request({ inviteToken: 'a'.repeat(32) }), { params: Promise.resolve({ id: '1' }) })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ data })
+  })
+})

--- a/__tests__/lib/reminders/engine.test.ts
+++ b/__tests__/lib/reminders/engine.test.ts
@@ -128,4 +128,28 @@ describe('ReminderEngine', () => {
     expect(() => createReminderEngine({ now: () => new Date(), provider: provider() }).validate(baseJob({ eventType: 'unknown' as never }))).toThrow()
     expect(() => createReminderEngine({ now: () => new Date(), provider: provider() }).validate(baseJob({ channel: 'sms' as never }))).toThrow()
   })
+
+  it('sends a concurrent duplicate only once', async () => {
+    let release!: () => void
+    const send = vi.fn(() => new Promise<void>((resolve) => {
+      release = resolve
+    }))
+    const engine = createReminderEngine({ now: () => new Date('2026-08-26T10:00:00.000Z'), provider: provider(send) })
+
+    const first = engine.process(baseJob())
+    const second = engine.process(baseJob())
+    await Promise.resolve()
+    expect(send).toHaveBeenCalledTimes(1)
+
+    release()
+    const results = await Promise.all([first, second])
+    expect(results[0].status).toBe('sent')
+    expect(results[1].status).toBe('sent')
+  })
+
+  it.each(['email', 'web_push', 'line'] as const)('rejects unapproved channel %s', (channel) => {
+    const engine = createReminderEngine({ now: () => new Date(), provider: provider() })
+
+    expect(() => engine.validate(baseJob({ channel }))).toThrow('Reminder channel is not approved')
+  })
 })

--- a/__tests__/lib/reminders/engine.test.ts
+++ b/__tests__/lib/reminders/engine.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createReminderEngine,
+  type ReminderJob,
+  type ReminderProvider,
+} from '@/lib/reminders/engine'
+
+const baseJob = (overrides: Partial<ReminderJob> = {}): ReminderJob => ({
+  eventId: 'birthday:2026-08-26',
+  eventType: 'birthday',
+  recipientRef: 'recipient-opaque',
+  channel: 'in_app',
+  scheduledAt: '2026-08-26T09:00:00.000Z',
+  timezone: 'Asia/Tokyo',
+  idempotencyKey: 'birthday:2026-08-26:recipient-opaque:in_app',
+  optedIn: true,
+  ...overrides,
+})
+
+const provider = (send: ReminderProvider['send'] = vi.fn().mockResolvedValue(undefined)): ReminderProvider => ({
+  send,
+})
+
+describe('ReminderEngine', () => {
+  it('processes an idempotency key only once', async () => {
+    const send = vi.fn().mockResolvedValue(undefined)
+    const engine = createReminderEngine({ now: () => new Date('2026-08-26T10:00:00.000Z'), provider: provider(send) })
+
+    const first = await engine.process(baseJob())
+    const second = await engine.process(baseJob())
+
+    expect(first.status).toBe('sent')
+    expect(second.status).toBe('sent')
+    expect(second.duplicate).toBe(true)
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-evaluates a pending job when its scheduled time arrives', async () => {
+    const send = vi.fn().mockResolvedValue(undefined)
+    let now = new Date('2026-08-26T08:00:00.000Z')
+    const engine = createReminderEngine({ now: () => now, provider: provider(send) })
+
+    const pending = await engine.process(baseJob())
+    now = new Date('2026-08-26T10:00:00.000Z')
+    const sent = await engine.process(baseJob())
+
+    expect(pending.status).toBe('pending')
+    expect(sent.status).toBe('sent')
+    expect(sent.duplicate).toBeUndefined()
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+
+  it('marks an expired job without calling the provider', async () => {
+    const send = vi.fn().mockResolvedValue(undefined)
+    const engine = createReminderEngine({ now: () => new Date('2026-08-26T10:00:00.000Z'), provider: provider(send) })
+
+    const result = await engine.process(baseJob({ expiresAt: '2026-08-26T09:00:00.000Z' }))
+
+    expect(result.status).toBe('expired')
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('deduplicates an opted-out result without sending', async () => {
+    const send = vi.fn().mockResolvedValue(undefined)
+    const engine = createReminderEngine({ now: () => new Date('2026-08-26T10:00:00.000Z'), provider: provider(send) })
+
+    const first = await engine.process(baseJob({ optedIn: false }))
+    const second = await engine.process(baseJob({ optedIn: false }))
+
+    expect(first.status).toBe('cancelled')
+    expect(second.status).toBe('cancelled')
+    expect(second.duplicate).toBe(true)
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('does not expose private content or personal identifiers in results', async () => {
+    const engine = createReminderEngine({ now: () => new Date('2026-08-26T08:00:00.000Z'), provider: provider() })
+
+    const result = await engine.process(baseJob({
+      recipientRef: 'opaque-recipient',
+      scheduledAt: '2026-08-26T12:00:00.000Z',
+    }))
+
+    expect(result).toEqual({ status: 'pending', attemptCount: 0 })
+    expect(JSON.stringify(result)).not.toMatch(/message|photo|token|ip|fingerprint/i)
+  })
+
+  it('skips opted-out recipients without calling the provider', async () => {
+    const send = vi.fn().mockResolvedValue(undefined)
+    const engine = createReminderEngine({ now: () => new Date('2026-08-26T10:00:00.000Z'), provider: provider(send) })
+
+    const result = await engine.process(baseJob({ optedIn: false }))
+
+    expect(result.status).toBe('cancelled')
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('retries transient failures up to the configured bound', async () => {
+    const send = vi.fn()
+      .mockRejectedValueOnce({ code: 'timeout', transient: true })
+      .mockResolvedValueOnce(undefined)
+    const engine = createReminderEngine({
+      now: () => new Date('2026-08-26T10:00:00.000Z'),
+      provider: provider(send),
+      maxAttempts: 2,
+    })
+
+    const result = await engine.process(baseJob())
+
+    expect(result.status).toBe('sent')
+    expect(result.attemptCount).toBe(2)
+    expect(send).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not retry permanent failures', async () => {
+    const send = vi.fn().mockRejectedValue({ code: 'invalid_recipient', transient: false })
+    const engine = createReminderEngine({ now: () => new Date('2026-08-26T10:00:00.000Z'), provider: provider(send) })
+
+    const result = await engine.process(baseJob())
+
+    expect(result.status).toBe('failed')
+    expect(result.attemptCount).toBe(1)
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects jobs with invalid timezone or event/channel values', () => {
+    expect(() => createReminderEngine({ now: () => new Date(), provider: provider() }).validate(baseJob({ timezone: 'Not/AZone' }))).toThrow()
+    expect(() => createReminderEngine({ now: () => new Date(), provider: provider() }).validate(baseJob({ eventType: 'unknown' as never }))).toThrow()
+    expect(() => createReminderEngine({ now: () => new Date(), provider: provider() }).validate(baseJob({ channel: 'sms' as never }))).toThrow()
+  })
+})

--- a/__tests__/lib/time-capsule-client.test.ts
+++ b/__tests__/lib/time-capsule-client.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const createClientMock = vi.hoisted(() => vi.fn())
+const getSupabaseMock = vi.hoisted(() => vi.fn())
 
-vi.mock('@supabase/supabase-js', () => ({ createClient: createClientMock }))
+vi.mock('@/lib/supabase/client', () => ({ getSupabase: getSupabaseMock }))
 
 import { createTimeCapsule, listTimeCapsules, redeemTimeCapsule, redeemTimeCapsuleByCode } from '@/lib/time-capsule-client'
 
@@ -18,7 +18,7 @@ const capsule = {
 describe('time-capsule auth bootstrap', () => {
   beforeEach(() => {
     vi.resetModules()
-    createClientMock.mockReset()
+    getSupabaseMock.mockReset()
     vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://example.supabase.co')
     vi.stubEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY', 'anon-key')
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
@@ -32,10 +32,11 @@ describe('time-capsule auth bootstrap', () => {
       data: { session: { access_token: 'anonymous-token' } },
       error: null,
     })
-    createClientMock.mockReturnValue({ auth: { getSession, signInAnonymously } })
+    getSupabaseMock.mockReturnValue({ auth: { getSession, signInAnonymously } })
 
     await listTimeCapsules()
 
+    expect(getSupabaseMock).toHaveBeenCalledTimes(1)
     expect(signInAnonymously).toHaveBeenCalledTimes(1)
     const [, request] = vi.mocked(fetch).mock.calls[0]
     expect(new Headers(request?.headers).get('Authorization')).toBe('Bearer anonymous-token')
@@ -51,8 +52,28 @@ describe('time-capsule auth bootstrap', () => {
       .resolves.toMatchObject({ accessCode: 'ABCD-EFGH', inviteToken: 'invite-token', inviteTokenExpiresAt: '2026-09-23T00:00:00.000Z' })
   })
 
+  it('shares an in-flight anonymous sign-in across concurrent requests', async () => {
+    let resolveSignIn: ((value: { data: { session: { access_token: string } }; error: null }) => void) | undefined
+    const getSession = vi.fn().mockReturnValue({ data: { session: null }, error: null })
+    const signInAnonymously = vi.fn().mockImplementation(() => new Promise((resolve) => {
+      resolveSignIn = resolve
+    }))
+    getSupabaseMock.mockReturnValue({ auth: { getSession, signInAnonymously } })
+    vi.mocked(fetch).mockImplementation(() => Promise.resolve(
+      new Response(JSON.stringify({ data: [capsule], count: 1 }), { status: 200 })
+    ))
+
+    const firstRequest = listTimeCapsules()
+    const secondRequest = listTimeCapsules()
+    await Promise.resolve()
+    expect(signInAnonymously).toHaveBeenCalledTimes(1)
+
+    resolveSignIn?.({ data: { session: { access_token: 'shared-token' } }, error: null })
+    await expect(Promise.all([firstRequest, secondRequest])).resolves.toHaveLength(2)
+  })
+
   it('redeems a capsule with its invite token without anonymous auth', async () => {
-    createClientMock.mockReturnValue({ auth: { getSession: vi.fn(), signInAnonymously: vi.fn() } })
+    getSupabaseMock.mockReturnValue({ auth: { getSession: vi.fn(), signInAnonymously: vi.fn() } })
     vi.mocked(fetch).mockResolvedValueOnce(new Response(JSON.stringify({ data: capsule }), { status: 200 }))
 
     await expect(redeemTimeCapsule('123', 'invite-token')).resolves.toMatchObject({ data: { id: 1 } })

--- a/__tests__/lib/time-capsule-server.test.ts
+++ b/__tests__/lib/time-capsule-server.test.ts
@@ -28,6 +28,7 @@ vi.mock('@supabase/supabase-js', () => ({ createClient }))
 import {
   createAccessCode,
   findByAccessCode,
+  TIME_CAPSULE_SELECT,
   getAccessAttemptBucketFingerprint,
   createInviteToken,
   findByInviteToken,
@@ -49,8 +50,18 @@ describe('Time Capsule server boundary', () => {
   })
 
   it('rejects malformed invite tokens before lookup', () => {
-    expect(() => parseInviteToken('short')).toThrowError(TimeCapsuleError)
+    expect(() => parseInviteToken('short')).toThrow(TimeCapsuleError)
     expect(createClient).not.toHaveBeenCalled()
+  })
+
+  it('keeps reads compatible before the open-tracking migration', async () => {
+    maybeSingle.mockResolvedValue({ data: { id: 1, message: 'secret' }, error: null })
+
+    const result = await findByInviteToken('a'.repeat(43))
+
+    expect(result.row).toEqual({ id: 1, message: 'secret' })
+    expect(query.select).toHaveBeenCalledWith(TIME_CAPSULE_SELECT)
+    expect(TIME_CAPSULE_SELECT).not.toContain('opened_at')
   })
 
   it('rejects expired or revoked invite lookup results', async () => {
@@ -104,9 +115,9 @@ describe('Time Capsule server boundary', () => {
   })
 
   it('rejects malformed access codes', () => {
-    expect(() => parseAccessCode('12345')).toThrowError(TimeCapsuleError)
-    expect(() => parseAccessCode('1234567')).toThrowError(TimeCapsuleError)
-    expect(() => parseAccessCode('abcdef')).toThrowError(TimeCapsuleError)
+    expect(() => parseAccessCode('12345')).toThrow(TimeCapsuleError)
+    expect(() => parseAccessCode('1234567')).toThrow(TimeCapsuleError)
+    expect(() => parseAccessCode('abcdef')).toThrow(TimeCapsuleError)
   })
 
   it('does not use spoofable proxy headers for the attempt bucket', () => {

--- a/__tests__/lib/time-capsule-server.test.ts
+++ b/__tests__/lib/time-capsule-server.test.ts
@@ -5,6 +5,7 @@ const { maybeSingle, query, rpc, createClient } = vi.hoisted(() => {
   const rpc = vi.fn()
   const query = {
     select: vi.fn(() => query),
+    update: vi.fn(() => query),
     eq: vi.fn(() => query),
     is: vi.fn(() => query),
     gt: vi.fn(() => query),
@@ -35,6 +36,7 @@ import {
   parseAccessCode,
   parseInviteToken,
   serializeCapsule,
+  recordFirstOpen,
   TimeCapsuleError,
 } from '@/lib/time-capsule/server'
 
@@ -145,5 +147,57 @@ describe('Time Capsule server boundary', () => {
     maybeSingle.mockResolvedValue({ data: null, error: null })
 
     await expect(findByAccessCode('123456', 'a'.repeat(64))).rejects.toMatchObject({ code: 'access_not_found', status: 404 })
+  })
+
+  it('records first open once for an unlocked capsule', async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({ data: { id: 1 }, error: null })
+    const select = vi.fn(() => ({ maybeSingle }))
+    const is = vi.fn(() => ({ select }))
+    const eq = vi.fn(() => ({ is }))
+    const update = vi.fn(() => ({ eq }))
+    const client = { from: vi.fn(() => ({ update })) } as never
+
+    const recorded = await recordFirstOpen(client, {
+      id: 1,
+      owner_id: 'owner-1',
+      sender: 'A',
+      recipient: null,
+      message: 'secret',
+      photo_url: null,
+      photo_object_path: null,
+      unlock_date: '2026-08-26',
+      created_at: '2026-01-01T00:00:00.000Z',
+      invite_token_hash: null,
+      invite_token_expires_at: null,
+      invite_revoked_at: null,
+    }, '2026-08-26T10:00:00.000Z')
+
+    expect(recorded).toBe(true)
+    expect(update).toHaveBeenCalledWith({ opened_at: '2026-08-26T10:00:00.000Z' })
+    expect(eq).toHaveBeenCalledWith('id', 1)
+    expect(is).toHaveBeenCalledWith('opened_at', null)
+  })
+
+  it('does not record a sealed capsule', async () => {
+    const from = vi.fn()
+    const client = { from } as never
+
+    const recorded = await recordFirstOpen(client, {
+      id: 1,
+      owner_id: 'owner-1',
+      sender: 'A',
+      recipient: null,
+      message: 'secret',
+      photo_url: null,
+      photo_object_path: null,
+      unlock_date: '2999-01-01',
+      created_at: '2026-01-01T00:00:00.000Z',
+      invite_token_hash: null,
+      invite_token_expires_at: null,
+      invite_revoked_at: null,
+    }, '2026-08-26T10:00:00.000Z')
+
+    expect(recorded).toBe(false)
+    expect(from).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/supabase-time-capsule-open-tracking-migration.test.ts
+++ b/__tests__/supabase-time-capsule-open-tracking-migration.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const migration = readFileSync(
+  resolve(process.cwd(), 'supabase/migrations/20260827000000_add_time_capsule_open_tracking.sql'),
+  'utf8'
+)
+
+describe('time capsule open tracking migration', () => {
+  it('adds nullable first-open tracking without public exposure', () => {
+    expect(migration).toContain('add column if not exists opened_at timestamptz')
+    expect(migration).toContain('time_capsules_opened_at_idx')
+    expect(migration).not.toContain('grant select')
+    expect(migration).not.toContain('create policy')
+  })
+})

--- a/app/api/time-capsules/[id]/access/route.ts
+++ b/app/api/time-capsules/[id]/access/route.ts
@@ -26,7 +26,15 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     }
     const { client, row } = await findByInviteToken(parseInviteToken(token), id)
     const data = await serializeCapsule(client, row)
-    if (data.isUnlocked === true) await recordFirstOpen(client, row)
+    if (data.isUnlocked === true) {
+      try {
+        await recordFirstOpen(client, row)
+      } catch (error) {
+        console.warn('[TimeCapsule] first-open tracking failed', {
+          error: error instanceof Error ? error.name : 'unknown_error',
+        })
+      }
+    }
     return Response.json(
       { data },
       { headers: { 'Cache-Control': 'no-store', 'Referrer-Policy': 'no-referrer' } }

--- a/app/api/time-capsules/[id]/access/route.ts
+++ b/app/api/time-capsules/[id]/access/route.ts
@@ -5,6 +5,7 @@ import {
   findByInviteToken,
   parseId,
   parseInviteToken,
+  recordFirstOpen,
   serializeCapsule,
 } from '@/lib/time-capsule/server'
 
@@ -24,8 +25,10 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       throw new TimeCapsuleError('invalid_invite_token', 401, '招待トークンが無効です')
     }
     const { client, row } = await findByInviteToken(parseInviteToken(token), id)
+    const data = await serializeCapsule(client, row)
+    if (data.isUnlocked === true) await recordFirstOpen(client, row)
     return Response.json(
-      { data: await serializeCapsule(client, row) },
+      { data },
       { headers: { 'Cache-Control': 'no-store', 'Referrer-Policy': 'no-referrer' } }
     )
   } catch (error) {

--- a/app/api/time-capsules/access/route.ts
+++ b/app/api/time-capsules/access/route.ts
@@ -21,7 +21,15 @@ export async function POST(request: NextRequest) {
     }
     const { client, row } = await findByAccessCode(parseAccessCode(accessCode), getAccessAttemptBucketFingerprint(request))
     const data = await serializeCapsule(client, row)
-    if (data.isUnlocked === true) await recordFirstOpen(client, row)
+    if (data.isUnlocked === true) {
+      try {
+        await recordFirstOpen(client, row)
+      } catch (error) {
+        console.warn('[TimeCapsule] first-open tracking failed', {
+          error: error instanceof Error ? error.name : 'unknown_error',
+        })
+      }
+    }
     return Response.json(
       { data },
       { headers: { 'Cache-Control': 'no-store', 'Referrer-Policy': 'no-referrer' } }

--- a/app/api/time-capsules/access/route.ts
+++ b/app/api/time-capsules/access/route.ts
@@ -5,6 +5,7 @@ import {
   findByAccessCode,
   getAccessAttemptBucketFingerprint,
   parseAccessCode,
+  recordFirstOpen,
   serializeCapsule,
 } from '@/lib/time-capsule/server'
 
@@ -19,8 +20,10 @@ export async function POST(request: NextRequest) {
       throw new TimeCapsuleError('invalid_access_code', 401, 'アクセスコードが無効です')
     }
     const { client, row } = await findByAccessCode(parseAccessCode(accessCode), getAccessAttemptBucketFingerprint(request))
+    const data = await serializeCapsule(client, row)
+    if (data.isUnlocked === true) await recordFirstOpen(client, row)
     return Response.json(
-      { data: await serializeCapsule(client, row) },
+      { data },
       { headers: { 'Cache-Control': 'no-store', 'Referrer-Policy': 'no-referrer' } }
     )
   } catch (error) {

--- a/components/3d/OmikujiCylinder3D.tsx
+++ b/components/3d/OmikujiCylinder3D.tsx
@@ -29,6 +29,7 @@ export function OmikujiCylinder3D({
   const isShakingRef = useRef(isShaking)
   const isRevealedRef = useRef(isRevealed)
   const onDrawRef = useRef(onDraw)
+  const fortuneNumberRef = useRef(fortuneNumber)
 
   useEffect(() => {
     isShakingRef.current = isShaking
@@ -41,6 +42,10 @@ export function OmikujiCylinder3D({
   useEffect(() => {
     onDrawRef.current = onDraw
   }, [onDraw])
+
+  useEffect(() => {
+    fortuneNumberRef.current = fortuneNumber
+  }, [fortuneNumber])
 
   useEffect(() => {
     const container = containerRef.current
@@ -368,7 +373,7 @@ export function OmikujiCylinder3D({
       stickCtx.font = '900 290px "Yu Mincho", "Hiragino Mincho ProN", serif'
       stickCtx.textAlign = 'center'
       stickCtx.textBaseline = 'middle'
-      const label = KANJI_NUMBERS[(fortuneNumber - 1) % KANJI_NUMBERS.length] || '第一番'
+      const label = KANJI_NUMBERS[(fortuneNumberRef.current - 1) % KANJI_NUMBERS.length] || '第一番'
       const chars = label.split('')
       chars.forEach((c, idx) => {
         stickCtx.strokeText(c, 256, 420 + idx * 360)

--- a/components/community/BulletinPost.tsx
+++ b/components/community/BulletinPost.tsx
@@ -141,6 +141,7 @@ export default function BulletinPost({ post, onLike, onReply }: BulletinPostProp
               preload="metadata"
             />
           ) : (
+            // eslint-disable-next-line @next/next/no-img-element
             <img
               src={post.media_url}
               alt={t('mediaAlt')}

--- a/components/community/CameraCapture.tsx
+++ b/components/community/CameraCapture.tsx
@@ -22,11 +22,16 @@ export function CameraCapture({ mode, onCapture, onClose }: CameraCaptureProps) 
   const mediaRecorderRef = useRef<MediaRecorder | null>(null)
   const chunksRef = useRef<Blob[]>([])
   const streamRef = useRef<MediaStream | null>(null)
-  
+  const translateRef = useRef(t)
+
   const [isRecording, setIsRecording] = useState(false)
   const [recordingTime, setRecordingTime] = useState(0)
   const [error, setError] = useState<string | null>(null)
   const [cameraReady, setCameraReady] = useState(false)
+
+  useEffect(() => {
+    translateRef.current = t
+  }, [t])
 
   useEffect(() => {
     let mounted = true
@@ -67,7 +72,7 @@ export function CameraCapture({ mode, onCapture, onClose }: CameraCaptureProps) 
                 })
                 .catch(err => {
                   console.error('Video play error:', err)
-                  if (mounted) setError(t('cameraPlaybackError'))
+                  if (mounted) setError(translateRef.current('cameraPlaybackError'))
                 })
             }
           }
@@ -77,11 +82,11 @@ export function CameraCapture({ mode, onCapture, onClose }: CameraCaptureProps) 
         const errorMessage = err instanceof Error ? err.message : 'Unknown error'
         if (mounted) {
           if (errorMessage.includes('Permission denied') || errorMessage.includes('NotAllowedError')) {
-            setError(t('cameraPermission'))
+            setError(translateRef.current('cameraPermission'))
           } else if (errorMessage.includes('NotFoundError') || errorMessage.includes('DevicesNotFoundError')) {
-            setError(t('cameraUnavailable'))
+            setError(translateRef.current('cameraUnavailable'))
           } else {
-            setError(`${t('accessCameraError')}: ${errorMessage}`)
+            setError(`${translateRef.current('accessCameraError')}: ${errorMessage}`)
           }
         }
       }

--- a/components/community/MessageForm.tsx
+++ b/components/community/MessageForm.tsx
@@ -308,6 +308,7 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
                   controls
                 />
               ) : (
+                // eslint-disable-next-line @next/next/no-img-element
                 <img
                   src={previewUrl || ''}
                   alt={t('preview')}

--- a/components/community/PostDetail.tsx
+++ b/components/community/PostDetail.tsx
@@ -198,6 +198,7 @@ export default function PostDetail({ post, onBack, onLike }: PostDetailProps) {
                 {post.media_url.endsWith('.mp4') || post.media_url.endsWith('.webm') || post.media_url.endsWith('.ogg') ? (
                   <video src={post.media_url} controls style={{ width: '100%', maxHeight: '400px', background: '#000' }} />
                 ) : (
+                  // eslint-disable-next-line @next/next/no-img-element
                   <img src={post.media_url} alt={t('mediaAlt')} style={{ width: '100%', maxHeight: '400px', objectFit: 'contain' }} />
                 )}
               </div>

--- a/components/community/PostForm.tsx
+++ b/components/community/PostForm.tsx
@@ -222,6 +222,7 @@ export default function PostForm({ onSubmit }: PostFormProps) {
               {isVideo ? (
                 <video src={previewUrl || ''} style={{ width: '100%', maxHeight: '150px', objectFit: 'contain' }} controls />
               ) : (
+                // eslint-disable-next-line @next/next/no-img-element
                 <img src={previewUrl || ''} alt={t('preview')} style={{ width: '100%', maxHeight: '150px', objectFit: 'contain' }} />
               )}
               <button type="button" onClick={removeFile}

--- a/components/community/TimeCapsule.tsx
+++ b/components/community/TimeCapsule.tsx
@@ -1,6 +1,6 @@
 ﻿'use client'
 
-import { useState, useEffect, useRef } from 'react'
+import { useCallback, useState, useEffect, useRef } from 'react'
 import { createTimeCapsule, deleteTimeCapsulePhoto, listTimeCapsules, redeemTimeCapsuleByCode, uploadTimeCapsulePhoto } from '@/lib/time-capsule-client'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { Icon } from '@/components/ui/Icon'
@@ -158,7 +158,7 @@ export function TimeCapsule() {
   const isSealingRef = useRef(false)
 
   // タイムカプセル一覧の取得およびローカル保存データの統合
-  const fetchCapsules = async () => {
+  const fetchCapsules = useCallback(async () => {
     if (!isMountedRef.current) return
     if (refreshInFlightRef.current) {
       refreshQueuedRef.current = true
@@ -176,6 +176,13 @@ export function TimeCapsule() {
         if (Array.isArray(parsed)) localRaw = parsed
       } catch {
         localRaw = []
+      }
+
+      const initialLocalCapsules = parseLocalCapsules(localRaw, now)
+      if (!hasLoadedCapsulesRef.current && initialLocalCapsules.length > 0) {
+        setCapsules(initialLocalCapsules)
+        hasLoadedCapsulesRef.current = true
+        setLoading(false)
       }
 
       const pendingRaw = localRaw.filter((item): item is PendingCapsule => (
@@ -257,7 +264,7 @@ export function TimeCapsule() {
         void fetchCapsules()
       }
     }
-  }
+  }, [])
 
   useEffect(() => {
     isMountedRef.current = true
@@ -270,7 +277,7 @@ export function TimeCapsule() {
       isMountedRef.current = false
       clearInterval(interval)
     }
-  }, [])
+  }, [fetchCapsules])
 
   // タイムカプセルの封印処理
   const handleSeal = async (e: React.FormEvent) => {
@@ -400,6 +407,8 @@ export function TimeCapsule() {
             <label className="block text-xs font-bold text-[#854D27]">
               {t('timeCapsuleAccessCodeLabel')}
               <input
+                id="time-capsule-access-code"
+                name="accessCode"
                 inputMode="numeric"
                 autoComplete="one-time-code"
                 maxLength={7}
@@ -475,6 +484,7 @@ export function TimeCapsule() {
                     <div>
                       {capsule.photoUrl && (
                         <div className="w-full h-44 rounded-xl overflow-hidden mb-3 border border-[#D4B08C]/50">
+                          {/* eslint-disable-next-line @next/next/no-img-element */}
                           <img
                             src={capsule.photoUrl}
                             alt={t('timeCapsulePhotoAlt')}
@@ -541,6 +551,8 @@ export function TimeCapsule() {
               {t('yourName')} <span className="text-red-500">*</span>
             </label>
             <input
+              id="time-capsule-sender"
+              name="sender"
               type="text"
               required
               value={sender}
@@ -555,6 +567,8 @@ export function TimeCapsule() {
               {t('recipientOptional')}
             </label>
             <input
+              id="time-capsule-recipient"
+              name="recipient"
               type="text"
               value={recipient}
               onChange={(e) => setRecipient(e.target.value)}
@@ -568,6 +582,8 @@ export function TimeCapsule() {
               {t('timeCapsuleUnlockDate')} <span className="text-red-500">*</span>
             </label>
             <input
+              id="time-capsule-unlock-date"
+              name="unlockDate"
               type="date"
               required
               value={unlockDate}
@@ -582,6 +598,8 @@ export function TimeCapsule() {
               {t('typeMessage')} <span className="text-red-500">*</span>
             </label>
             <textarea
+              id="time-capsule-message"
+              name="message"
               required
               rows={3}
               value={message}
@@ -596,6 +614,8 @@ export function TimeCapsule() {
               {t('attachPhotoOptional')}
             </label>
             <input
+              id="time-capsule-photo"
+              name="photo"
               ref={fileInputRef}
               type="file"
               accept="image/*"

--- a/components/features/MediaViewer.tsx
+++ b/components/features/MediaViewer.tsx
@@ -443,6 +443,8 @@ export function MediaViewer({
               onPlay={() => setIsPlaying(false)}
             />
           ) : (
+            // Media paths may be private or signed URLs and are not statically allowlisted.
+            // eslint-disable-next-line @next/next/no-img-element
             <img
               src={media.file_path}
               alt={media.file_name}

--- a/components/features/OnThisDayFlashback.tsx
+++ b/components/features/OnThisDayFlashback.tsx
@@ -135,6 +135,8 @@ export function OnThisDayFlashback({ onClose }: { onClose?: () => void }) {
                     <audio src={currentMemory.mediaUrl} controls className="w-full" />
                   </div>
                 ) : (
+                  // Dynamic community media URLs are not statically allowlisted for next/image.
+                  // eslint-disable-next-line @next/next/no-img-element
                   <img
                     src={currentMemory.mediaUrl}
                     alt={t('flashbackPhotoAlt')}

--- a/components/features/PhotoCard.tsx
+++ b/components/features/PhotoCard.tsx
@@ -63,6 +63,8 @@ export function PhotoCard({ media, onClick }: PhotoCardProps) {
           muted
         />
       ) : (
+        // Media paths are dynamic and may be private; next/image cannot safely resolve them here.
+        // eslint-disable-next-line @next/next/no-img-element
         <img
           src={imageError ? '/placeholder-image.png' : media.file_path}
           alt={media.file_name}

--- a/components/features/PhotoFrame.tsx
+++ b/components/features/PhotoFrame.tsx
@@ -7,7 +7,7 @@ import { photoStrips, frameCategories, PhotoStripConfig } from '@/config/frames'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 
 export default function PhotoFrame() {
-  const { t, language } = useLanguage()
+  const { t } = useLanguage()
   const [selectedStrip, setSelectedStrip] = useState<PhotoStripConfig>(photoStrips[0])
   const [selectedCategory, setSelectedCategory] = useState<string>('trending')
   const [userImages, setUserImages] = useState<(string | null)[]>([null, null, null, null])
@@ -356,6 +356,7 @@ export default function PhotoFrame() {
                   style={{ borderColor: activeSlot === i ? selectedStrip.borderColor : undefined }}
                 >
                   {userImages[i] ? (
+                    // eslint-disable-next-line @next/next/no-img-element
                     <img src={userImages[i]!} alt={t('photoPlaceholder', { index: i + 1 })} />
                   ) : (
                     <Plus size={20} color="#999" />

--- a/components/features/Slideshow.tsx
+++ b/components/features/Slideshow.tsx
@@ -103,6 +103,8 @@ export function Slideshow({ media, autoPlay = true, interval = 5000, onClose }: 
                 }}
               />
             ) : (
+              // Media paths may be private or signed URLs and are not statically allowlisted.
+              // eslint-disable-next-line @next/next/no-img-element
               <img
                 src={currentMedia.file_path}
                 alt={currentMedia.file_name}

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -192,6 +192,8 @@ export function CardImage({ src, alt, aspectRatio = 'video', overlay = false }: 
 
   return (
     <div className={`relative ${aspectClasses[aspectRatio]} -mx-5 -mt-5 mb-4 overflow-hidden rounded-t-2xl`}>
+      {/* src is caller-provided and may be private or signed; no remote allowlist is available. */}
+      {/* eslint-disable-next-line @next/next/no-img-element */}
       <img src={src} alt={alt} className="w-full h-full object-cover" />
       {overlay && <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent" />}
     </div>

--- a/components/ui/LanguageSelector.tsx
+++ b/components/ui/LanguageSelector.tsx
@@ -14,6 +14,8 @@ export function LanguageSelector() {
   return (
     <div className="language-selector">
       <select
+        id="language-selector"
+        name="language"
         value={language}
         onChange={(e) => setLanguage(e.target.value as Language)}
         className="lang-select"

--- a/docs/reminder-and-capsule-lifecycle.md
+++ b/docs/reminder-and-capsule-lifecycle.md
@@ -1,0 +1,26 @@
+# Reminder と Time Capsule の lifecycle 方針
+
+この文書は、Reminder と Time Capsule の lifecycle を同じレビュー単位で扱うための作業範囲を定義します。実装前に契約と privacy 境界を確認し、未承認の scheduler、migration、外部通知、tracking 有効化を行わないことを前提にします。
+
+## 対象 Issue
+
+- #37 Reminder の recipient・channel 契約
+- #38 Reminder log の schema proposal
+- #39 Reminder Engine の重複防止と失敗処理
+- #44 Time Capsule の open tracking と privacy 契約
+
+## 実施順序
+
+1. recipient、channel、identity、opt-in/opt-out、timezone、retry、idempotency、retention を定義する
+2. notification log と open tracking の保存項目、制約、認可境界を proposal 化する
+3. 承認済みの契約だけを Reminder Engine と最小 tracking 実装へ渡す
+4. targeted test、typecheck、lint、build、diff check を実行する
+
+## 保持しない情報
+
+- plaintext secret
+- Time Capsule の本文や写真
+- 不要な IP アドレス
+- device fingerprint
+
+本番データベースへの DDL/DML、production scheduler の有効化、外部 provider への実送信は、明示的な承認と別の検証手順が完了するまで実行しません。

--- a/docs/reminder-contract.md
+++ b/docs/reminder-contract.md
@@ -25,6 +25,16 @@
 
 `optedIn=false` の recipient には送信しません。job/log は最小限の metadata と safe error code だけを保持し、本文、写真、secret、IP、device fingerprint は保持しません。具体的な retention 期間は production storage を追加する前に承認します。
 
+## 承認状態
+
+- 状態: `approved`
+- 承認範囲: `in_app` のみ
+- `email`、`web_push`、`line` は provider、privacy、運用手順の承認が完了するまで無効にします
+- opt-in の既定値は `false` とし、明示的な同意がない recipient には送信しません
+- retry は transient failure に限り、最大 3 回までとします
+- `opened_at` の保存期間は 90 日とし、期限後に削除します
+- retention の実装は、対象 storage と削除ジョブの承認後に追加します
+
 ## 承認境界
 
 この PR では contract と pure domain validation のみを追加します。production scheduler、database migration、provider への実送信は実行しません。

--- a/docs/reminder-contract.md
+++ b/docs/reminder-contract.md
@@ -1,0 +1,30 @@
+# Reminder 契約
+
+## 対象イベント
+
+- `birthday`: 誕生日の通知
+- `capsule_unlock`: Time Capsule の開封日時通知
+
+## Recipient と identity
+
+通知先は server-side で解決した opaque な `recipientRef` で表します。メールアドレス、LINE ID、本文、写真、raw token は job や log に保存しません。
+
+## Channel
+
+`in_app`、`email`、`web_push`、`line` を契約上の候補とします。provider 送信は channel ごとの opt-in と実装承認が完了するまで無効にします。現在の pure Engine は provider boundary を受け取るだけで、送信先を直接呼び出しません。
+
+## Timing と timezone
+
+`scheduleAt` は UTC の ISO 8601 timestamp、`timezone` は IANA timezone とします。過去の job は即時実行せず、scheduler 側で扱いを決定します。期限を過ぎた job は `expired` として扱います。
+
+## Retry と idempotency
+
+`idempotencyKey` は event、recipient、channel を含む stable な値とします。同じ key は一度だけ provider に渡します。retry は transient failure に限り、最大試行回数を超えません。永続的な failure は `failed` として記録します。
+
+## Opt-out と retention
+
+`optedIn=false` の recipient には送信しません。job/log は最小限の metadata と safe error code だけを保持し、本文、写真、secret、IP、device fingerprint は保持しません。具体的な retention 期間は production storage を追加する前に承認します。
+
+## 承認境界
+
+この PR では contract と pure domain validation のみを追加します。production scheduler、database migration、provider への実送信は実行しません。

--- a/docs/reminder-log-schema.md
+++ b/docs/reminder-log-schema.md
@@ -1,0 +1,31 @@
+# Reminder log schema proposal
+
+この proposal は #37 の contract を実装へ渡すための最小構造です。本番 migration は実行しません。
+
+| Field | 型 | 方針 |
+| --- | --- | --- |
+| `event_id` | text | 必須。birthday または capsule unlock の event 識別子 |
+| `event_type` | enum | `birthday` または `capsule_unlock` |
+| `recipient_ref` | text | server-side の opaque reference。連絡先を平文保存しない |
+| `channel` | enum | `in_app`、`email`、`web_push`、`line` |
+| `scheduled_at` | timestamptz | UTC の実行予定時刻 |
+| `timezone` | text | IANA timezone |
+| `status` | enum | `pending`、`processing`、`sent`、`retryable`、`failed`、`cancelled`、`expired` |
+| `attempt_count` | integer | 0 以上。bounded retry 用 |
+| `last_error_code` | text | provider の safe error code だけ |
+| `idempotency_key` | text | 必須かつ unique。重複送信を防止 |
+| `sent_at` | timestamptz | 送信完了時刻。未送信は null |
+| `created_at` | timestamptz | 作成時刻 |
+| `updated_at` | timestamptz | 更新時刻 |
+
+## Constraint と index proposal
+
+- `idempotency_key` は unique にする
+- `attempt_count` は 0 以上にする
+- `scheduled_at`、`sent_at`、`created_at` は UTC として扱う
+- `status, scheduled_at` の複合 index で due job を取得する
+- opt-out 判定に必要な `recipient_ref` の index は retention 契約と query が確定してから追加する
+
+## 保存しない情報
+
+message、photo URL、access token、secret、IP address、User-Agent、device fingerprint、provider credential は保存しません。retention 期間は contract 承認後に決定し、未承認の migration は作成しません。

--- a/docs/time-capsule-open-tracking.md
+++ b/docs/time-capsule-open-tracking.md
@@ -1,0 +1,22 @@
+# Time Capsule open tracking contract
+
+Open tracking は、正しい access boundary を通過し、server が unlocked content を返した最初の時点だけを記録します。sealed response では open event を作成しません。
+
+## 最小限のデータ
+
+- `capsule_id` または opaque な capsule reference
+- UTC の `opened_at`
+
+個人 identity、IP address、User-Agent、device fingerprint、raw invite token、raw access code、message、photo URL は保存しません。
+
+## 記録ルール
+
+- access が正しくても capsule が sealed の場合は記録しません
+- access code または invite token が不正、revoked、expired の場合は記録しません
+- capsule が最初に unlocked された時点で timestamp を一度だけ記録します
+- 同じ capsule を再度 redeem しても timestamp を変更せず、duplicate event を作成しません
+- Reminder delivery と open tracking は別の contract として扱います
+
+## Boundary
+
+Tracking は server-side access boundary で authorization が完了した後に実行し、public Data API には公開しません。persistence と retention の仕組みは、identity/privacy contract が明示的に承認されてから追加します。この PR では migration を作成せず、production の tracking も有効化しません。

--- a/lib/hooks/useMediaFiles.ts
+++ b/lib/hooks/useMediaFiles.ts
@@ -46,6 +46,8 @@ function toMediaFile(submission: MediaSubmission): MediaFile {
 export function useMediaFiles(): UseMediaFilesReturn {
   const { t } = useLanguage()
   const tRef = useRef(t)
+  const cacheTimeRef = useRef(0)
+  const filesLengthRef = useRef(0)
   useEffect(() => {
     tRef.current = t
   }, [t])
@@ -55,9 +57,12 @@ export function useMediaFiles(): UseMediaFilesReturn {
   const [stats, setStats] = useState<MediaStats | null>(null)
   const [cacheTime, setCacheTime] = useState(0)
 
+  cacheTimeRef.current = cacheTime
+  filesLengthRef.current = files.length
+
   const fetchFiles = useCallback(async (forceRefresh = false) => {
     const now = Date.now()
-    if (!forceRefresh && cacheTime > 0 && now - cacheTime < CACHE_EXPIRY_TIME && files.length > 0) return
+    if (!forceRefresh && cacheTimeRef.current > 0 && now - cacheTimeRef.current < CACHE_EXPIRY_TIME && filesLengthRef.current > 0) return
 
     setIsLoading(true)
     setError(null)
@@ -91,11 +96,11 @@ export function useMediaFiles(): UseMediaFilesReturn {
     } finally {
       setIsLoading(false)
     }
-  }, [cacheTime, files.length])
+  }, [])
 
   useEffect(() => {
     void fetchFiles()
-  }, [])
+  }, [fetchFiles])
 
   const uploadFile = useCallback(async (file: File): Promise<MediaFile | null> => {
     try {

--- a/lib/hooks/useMusicPlayer.ts
+++ b/lib/hooks/useMusicPlayer.ts
@@ -43,14 +43,34 @@ export function useMusicPlayer(customTracks?: Track[]): UseMusicPlayerReturn {
   const [currentTime, setCurrentTime] = useState(0)
   const [duration, setDuration] = useState(0)
   const audioRef = useRef<HTMLAudioElement | null>(null)
+  const volumeRef = useRef(volume)
+  const trackCountRef = useRef(tracks.length)
+  const currentTrackRef = useRef<Track | null>(null)
+  const isPlayingRef = useRef(isPlaying)
 
   const currentTrack = tracks[currentTrackIndex] || null
+
+  useEffect(() => {
+    volumeRef.current = volume
+  }, [volume])
+
+  useEffect(() => {
+    trackCountRef.current = tracks.length
+  }, [tracks.length])
+
+  useEffect(() => {
+    currentTrackRef.current = currentTrack
+  }, [currentTrack])
+
+  useEffect(() => {
+    isPlayingRef.current = isPlaying
+  }, [isPlaying])
 
   // オーディオ要素を初期化
   useEffect(() => {
     if (typeof window !== 'undefined' && !audioRef.current) {
       audioRef.current = new Audio()
-      audioRef.current.volume = volume
+      audioRef.current.volume = volumeRef.current
 
       audioRef.current.addEventListener('timeupdate', () => {
         setCurrentTime(audioRef.current?.currentTime || 0)
@@ -62,7 +82,7 @@ export function useMusicPlayer(customTracks?: Track[]): UseMusicPlayerReturn {
 
       audioRef.current.addEventListener('ended', () => {
         // 次のトラックを自動再生
-        setCurrentTrackIndex(prev => (prev + 1) % tracks.length)
+        setCurrentTrackIndex(prev => (prev + 1) % trackCountRef.current)
       })
 
       // オーディオ読み込みエラーを静かに処理
@@ -82,9 +102,11 @@ export function useMusicPlayer(customTracks?: Track[]): UseMusicPlayerReturn {
 
   // トラックが変更されたらオーディオソースを更新
   useEffect(() => {
-    if (audioRef.current && currentTrack) {
-      const wasPlaying = isPlaying
-      audioRef.current.src = currentTrack.url
+    if (audioRef.current && currentTrackRef.current) {
+      const nextTrack = currentTrackRef.current
+      const wasPlaying = isPlayingRef.current
+      if (!nextTrack) return
+      audioRef.current.src = nextTrack.url
       audioRef.current.load()
 
       if (wasPlaying) {

--- a/lib/reminders/engine.ts
+++ b/lib/reminders/engine.ts
@@ -2,6 +2,7 @@ export const REMINDER_EVENT_TYPES = ['birthday', 'capsule_unlock'] as const
 export type ReminderEventType = (typeof REMINDER_EVENT_TYPES)[number]
 
 export const REMINDER_CHANNELS = ['in_app', 'email', 'web_push', 'line'] as const
+export const APPROVED_REMINDER_CHANNELS = ['in_app'] as const
 export type ReminderChannel = (typeof REMINDER_CHANNELS)[number]
 
 export const REMINDER_STATUSES = ['pending', 'processing', 'sent', 'retryable', 'failed', 'cancelled', 'expired'] as const
@@ -71,6 +72,7 @@ function validateScheduledAt(value: string): Date {
 export function createReminderEngine(options: ReminderEngineOptions) {
   const maxAttempts = Math.max(1, Math.floor(options.maxAttempts ?? 3))
   const results = new Map<string, ReminderResult>()
+  const inFlight = new Map<string, Promise<ReminderResult>>()
 
   const validate = (job: ReminderJob): void => {
     if (!job.eventId.trim() || !job.recipientRef.trim() || !job.idempotencyKey.trim()) {
@@ -78,6 +80,7 @@ export function createReminderEngine(options: ReminderEngineOptions) {
     }
     if (!isAllowed(job.eventType, REMINDER_EVENT_TYPES)) throw new Error('Invalid reminder event type')
     if (!isAllowed(job.channel, REMINDER_CHANNELS)) throw new Error('Invalid reminder channel')
+    if (!isAllowed(job.channel, APPROVED_REMINDER_CHANNELS)) throw new Error('Reminder channel is not approved')
     validateTimezone(job.timezone)
     validateScheduledAt(job.scheduledAt)
     if (job.expiresAt) validateScheduledAt(job.expiresAt)
@@ -107,27 +110,39 @@ export function createReminderEngine(options: ReminderEngineOptions) {
       return result
     }
 
-    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-      try {
-        await options.provider.send(job)
-        const result: ReminderResult = { status: 'sent', attemptCount: attempt }
-        results.set(job.idempotencyKey, result)
-        return result
-      } catch (error) {
-        const failure = parseFailure(error)
-        if (!failure.transient || attempt === maxAttempts) {
-          const result: ReminderResult = {
-            status: 'failed',
-            attemptCount: attempt,
-            errorCode: failure.code ?? 'provider_failure',
-          }
+    const existingInFlight = inFlight.get(job.idempotencyKey)
+    if (existingInFlight) return { ...(await existingInFlight), duplicate: true }
+
+    const operation = (async (): Promise<ReminderResult> => {
+      for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+        try {
+          await options.provider.send(job)
+          const result: ReminderResult = { status: 'sent', attemptCount: attempt }
           results.set(job.idempotencyKey, result)
           return result
+        } catch (error) {
+          const failure = parseFailure(error)
+          if (!failure.transient || attempt === maxAttempts) {
+            const result: ReminderResult = {
+              status: 'failed',
+              attemptCount: attempt,
+              errorCode: failure.code ?? 'provider_failure',
+            }
+            results.set(job.idempotencyKey, result)
+            return result
+          }
         }
       }
-    }
 
-    throw new Error('Reminder processing did not settle')
+      throw new Error('Reminder processing did not settle')
+    })()
+    inFlight.set(job.idempotencyKey, operation)
+
+    try {
+      return await operation
+    } finally {
+      inFlight.delete(job.idempotencyKey)
+    }
   }
 
   return { validate, process }

--- a/lib/reminders/engine.ts
+++ b/lib/reminders/engine.ts
@@ -1,0 +1,134 @@
+export const REMINDER_EVENT_TYPES = ['birthday', 'capsule_unlock'] as const
+export type ReminderEventType = (typeof REMINDER_EVENT_TYPES)[number]
+
+export const REMINDER_CHANNELS = ['in_app', 'email', 'web_push', 'line'] as const
+export type ReminderChannel = (typeof REMINDER_CHANNELS)[number]
+
+export const REMINDER_STATUSES = ['pending', 'processing', 'sent', 'retryable', 'failed', 'cancelled', 'expired'] as const
+export type ReminderStatus = (typeof REMINDER_STATUSES)[number]
+
+export interface ReminderJob {
+  eventId: string
+  eventType: ReminderEventType
+  recipientRef: string
+  channel: ReminderChannel
+  scheduledAt: string
+  timezone: string
+  idempotencyKey: string
+  optedIn: boolean
+  expiresAt?: string
+}
+
+export interface ReminderProvider {
+  send(job: ReminderJob): Promise<void>
+}
+
+export interface ReminderResult {
+  status: Exclude<ReminderStatus, 'processing'>
+  attemptCount: number
+  duplicate?: boolean
+  errorCode?: string
+}
+
+export interface ReminderEngineOptions {
+  now: () => Date
+  provider: ReminderProvider
+  maxAttempts?: number
+}
+
+interface ReminderFailure {
+  code?: string
+  transient?: boolean
+}
+
+function isAllowed<T extends readonly string[]>(value: string, allowed: T): value is T[number] {
+  return allowed.includes(value)
+}
+
+function parseFailure(error: unknown): ReminderFailure {
+  if (typeof error !== 'object' || error === null) return {}
+  const failure = error as Record<string, unknown>
+  return {
+    code: typeof failure.code === 'string' ? failure.code : undefined,
+    transient: failure.transient === true,
+  }
+}
+
+function validateTimezone(timezone: string): void {
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: timezone }).format()
+  } catch {
+    throw new Error('Invalid IANA timezone')
+  }
+}
+
+function validateScheduledAt(value: string): Date {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) throw new Error('Invalid scheduledAt')
+  return date
+}
+
+export function createReminderEngine(options: ReminderEngineOptions) {
+  const maxAttempts = Math.max(1, Math.floor(options.maxAttempts ?? 3))
+  const results = new Map<string, ReminderResult>()
+
+  const validate = (job: ReminderJob): void => {
+    if (!job.eventId.trim() || !job.recipientRef.trim() || !job.idempotencyKey.trim()) {
+      throw new Error('Reminder identifiers are required')
+    }
+    if (!isAllowed(job.eventType, REMINDER_EVENT_TYPES)) throw new Error('Invalid reminder event type')
+    if (!isAllowed(job.channel, REMINDER_CHANNELS)) throw new Error('Invalid reminder channel')
+    validateTimezone(job.timezone)
+    validateScheduledAt(job.scheduledAt)
+    if (job.expiresAt) validateScheduledAt(job.expiresAt)
+  }
+
+  const process = async (job: ReminderJob): Promise<ReminderResult> => {
+    validate(job)
+    const now = options.now()
+    const scheduledAt = validateScheduledAt(job.scheduledAt)
+    const existing = results.get(job.idempotencyKey)
+    if (existing && (existing.status !== 'pending' || scheduledAt > now)) {
+      return { ...existing, duplicate: true }
+    }
+    if (!job.optedIn) {
+      const result: ReminderResult = { status: 'cancelled', attemptCount: 0 }
+      results.set(job.idempotencyKey, result)
+      return result
+    }
+    if (job.expiresAt && now >= validateScheduledAt(job.expiresAt)) {
+      const result: ReminderResult = { status: 'expired', attemptCount: 0 }
+      results.set(job.idempotencyKey, result)
+      return result
+    }
+    if (scheduledAt > now) {
+      const result: ReminderResult = { status: 'pending', attemptCount: 0 }
+      results.set(job.idempotencyKey, result)
+      return result
+    }
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      try {
+        await options.provider.send(job)
+        const result: ReminderResult = { status: 'sent', attemptCount: attempt }
+        results.set(job.idempotencyKey, result)
+        return result
+      } catch (error) {
+        const failure = parseFailure(error)
+        if (!failure.transient || attempt === maxAttempts) {
+          const result: ReminderResult = {
+            status: 'failed',
+            attemptCount: attempt,
+            errorCode: failure.code ?? 'provider_failure',
+          }
+          results.set(job.idempotencyKey, result)
+          return result
+        }
+      }
+    }
+
+    throw new Error('Reminder processing did not settle')
+  }
+
+  return { validate, process }
+}

--- a/lib/stores/uiStore.ts
+++ b/lib/stores/uiStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 
-export type ModalType = 
+export type ModalType =
   | 'album'
   | 'message'
   | 'bulletin'

--- a/lib/time-capsule-client.ts
+++ b/lib/time-capsule-client.ts
@@ -1,4 +1,4 @@
-import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { getSupabase } from '@/lib/supabase/client'
 
 export interface TimeCapsuleRow {
   id: string | number
@@ -41,30 +41,30 @@ export interface CreateTimeCapsuleResponse {
   idempotent?: boolean
 }
 
-let browserClient: SupabaseClient | null = null
-
-function getBrowserClient(): SupabaseClient {
-  if (browserClient) return browserClient
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-  if (!url || !key) throw new Error('Supabase anonymous authentication is unavailable')
-  browserClient = createClient(url, key, {
-    auth: { persistSession: true, autoRefreshToken: true, detectSessionInUrl: false },
-  })
-  return browserClient
-}
+let accessTokenPromise: Promise<string> | null = null
 
 async function ensureAccessToken(): Promise<string> {
-  const client = getBrowserClient()
-  const current = await client.auth.getSession()
-  if (current.error) throw new Error('Supabase session could not be read')
-  if (current.data.session?.access_token) return current.data.session.access_token
+  if (accessTokenPromise) return accessTokenPromise
 
-  const anonymous = await client.auth.signInAnonymously()
-  if (anonymous.error || !anonymous.data.session?.access_token) {
-    throw new Error('Anonymous authentication is disabled')
+  accessTokenPromise = (async () => {
+    const client = getSupabase()
+    const current = await client.auth.getSession()
+    if (current.error) throw new Error('Supabase session could not be read')
+    if (current.data.session?.access_token) return current.data.session.access_token
+
+    const anonymous = await client.auth.signInAnonymously()
+    if (anonymous.error || !anonymous.data.session?.access_token) {
+      throw new Error('Anonymous authentication is disabled')
+    }
+    return anonymous.data.session.access_token
+  })()
+
+  const pendingAccessToken = accessTokenPromise
+  try {
+    return await pendingAccessToken
+  } finally {
+    if (accessTokenPromise === pendingAccessToken) accessTokenPromise = null
   }
-  return anonymous.data.session.access_token
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -137,7 +137,7 @@ export async function uploadTimeCapsulePhoto(file: File): Promise<string> {
   if (!response.ok || !isRecord(body) || typeof body.path !== 'string' || typeof body.token !== 'string') {
     throw new Error('写真をアップロードできません')
   }
-  const { error } = await getBrowserClient().storage.from('time-capsules-private').uploadToSignedUrl(body.path, body.token, file)
+  const { error } = await getSupabase().storage.from('time-capsules-private').uploadToSignedUrl(body.path, body.token, file)
   if (error) throw new Error('写真をアップロードできません')
   return body.path
 }

--- a/lib/time-capsule/server.ts
+++ b/lib/time-capsule/server.ts
@@ -2,7 +2,7 @@ import { createHash, createHmac, randomInt } from 'node:crypto'
 import { createClient, type SupabaseClient, type User } from '@supabase/supabase-js'
 
 export const TIME_CAPSULE_SELECT =
-  'id,owner_id,sender,recipient,message,photo_url,photo_object_path,unlock_date,created_at,invite_token_hash,invite_token_expires_at,invite_revoked_at,opened_at'
+  'id,owner_id,sender,recipient,message,photo_url,photo_object_path,unlock_date,created_at,invite_token_hash,invite_token_expires_at,invite_revoked_at'
 
 export type CapsuleRow = {
   id: number

--- a/lib/time-capsule/server.ts
+++ b/lib/time-capsule/server.ts
@@ -2,7 +2,7 @@ import { createHash, createHmac, randomInt } from 'node:crypto'
 import { createClient, type SupabaseClient, type User } from '@supabase/supabase-js'
 
 export const TIME_CAPSULE_SELECT =
-  'id,owner_id,sender,recipient,message,photo_url,photo_object_path,unlock_date,created_at,invite_token_hash,invite_token_expires_at,invite_revoked_at'
+  'id,owner_id,sender,recipient,message,photo_url,photo_object_path,unlock_date,created_at,invite_token_hash,invite_token_expires_at,invite_revoked_at,opened_at'
 
 export type CapsuleRow = {
   id: number
@@ -17,6 +17,7 @@ export type CapsuleRow = {
   invite_token_hash: string | null
   invite_token_expires_at: string | null
   invite_revoked_at: string | null
+  opened_at?: string | null
 }
 
 export type CapsuleInput = {
@@ -203,6 +204,25 @@ export async function serializeCapsule(client: SupabaseClient, row: CapsuleRow):
     if (data?.signedUrl) result.photoUrl = data.signedUrl
   }
   return result
+}
+
+export async function recordFirstOpen(
+  client: SupabaseClient,
+  row: CapsuleRow,
+  openedAt = new Date().toISOString()
+): Promise<boolean> {
+  if (row.invite_revoked_at !== null || row.unlock_date > openedAt.slice(0, 10)) return false
+
+  const { data, error } = await client
+    .from('time_capsules')
+    .update({ opened_at: openedAt })
+    .eq('id', row.id)
+    .is('opened_at', null)
+    .select('id')
+    .maybeSingle()
+
+  if (error) throw new TimeCapsuleError('tracking_failed', 500, '開封記録を保存できません')
+  return data !== null
 }
 
 export async function findByInviteToken(token: string, id?: number) {

--- a/supabase/migrations/20260827000000_add_time_capsule_open_tracking.sql
+++ b/supabase/migrations/20260827000000_add_time_capsule_open_tracking.sql
@@ -1,0 +1,10 @@
+begin;
+
+alter table public.time_capsules
+  add column if not exists opened_at timestamptz;
+
+create index if not exists time_capsules_opened_at_idx
+  on public.time_capsules (opened_at)
+  where opened_at is not null;
+
+commit;


### PR DESCRIPTION
## 概要
Reminder と Time Capsule の lifecycle を、契約、schema、実行、privacy の順に整理します。recipient/channel、notification log、Reminder Engine、first-open tracking の境界を一つのレビュー面で管理します。production scheduler、migration、外部 provider 送信、tracking 有効化は承認まで行いません。

## Implementation checklist
- [x] #37 Reminder の recipient・channel 契約を決定する
- [x] #38 Reminder log の schema proposal を作成する
- [x] #39 Reminder Engine の重複防止と失敗処理を実装する
- [x] #44 Time Capsule の open tracking を privacy 契約後に追加する

## Verification checklist
- [x] #37 の event、recipient、channel、opt-in/opt-out、timezone、retry、idempotency、retention 契約を確認する
- [x] #38 の schema、制約、privacy、retention、index proposal を確認する
- [x] #39 の typed contract、duplicate prevention、bounded retry、opt-out、failed state の test を確認する
- [x] #44 の identity、authorization、duplicate prevention、privacy、retention を確認する
- [x] 本番 migration、scheduler、tracking、外部 provider 送信を実行していないことを確認する
- [x] self-review、typecheck、lint、targeted tests、build、diff check を実行する
- [x] review threads、CI、security findings を最終確認する

## References
Refs #37
Refs #38
Refs #39
Refs #44