### PR TITLE
Production boundary・healthcheck・read-only attestation の残課題対応

### DIFF
--- a/.github/workflows/supabase-healthcheck.yml
+++ b/.github/workflows/supabase-healthcheck.yml
@@ -56,17 +56,52 @@ jobs:
             --no-psqlrc \
             --set=ON_ERROR_STOP=1 \
             --tuples-only \
-            --command="SELECT current_user = session_user
-              AND r.rolname = current_user
-              AND NOT r.rolsuper
-              AND NOT r.rolbypassrls
-              AND NOT r.rolcreatedb
-              AND NOT r.rolcreaterole
-              AND NOT r.rolreplication
-              AND r.rolinherit
-              AND r.rolcanlogin
-            FROM pg_roles AS r
-            WHERE r.rolname = current_user;" \
+            --command="WITH role_attrs AS ( \
+              SELECT r.rolname = current_user AS role_name_matches, \
+                     current_user = session_user AS identity_matches, \
+                     r.rolcanlogin, NOT r.rolsuper AS no_superuser, \
+                     NOT r.rolcreaterole AS no_createrole, NOT r.rolcreatedb AS no_createdb, \
+                     NOT r.rolreplication AS no_replication, NOT r.rolbypassrls AS no_bypassrls \
+              FROM pg_roles AS r \
+              WHERE r.rolname = current_user \
+            ), schemas AS ( \
+              SELECT n.oid \
+              FROM pg_namespace AS n \
+              WHERE n.nspname IN ('public', 'storage') \
+            ), objects AS ( \
+              SELECT c.oid \
+              FROM pg_class AS c \
+              JOIN pg_namespace AS n ON n.oid = c.relnamespace \
+              WHERE n.nspname IN ('public', 'storage') \
+                AND c.relkind IN ('r', 'p', 'v', 'f', 'm') \
+            ), effective_privileges AS ( \
+              SELECT NOT EXISTS ( \
+                       SELECT 1 FROM objects AS o \
+                       WHERE has_table_privilege(current_user, o.oid, 'INSERT') \
+                          OR has_table_privilege(current_user, o.oid, 'UPDATE') \
+                          OR has_table_privilege(current_user, o.oid, 'DELETE') \
+                          OR has_table_privilege(current_user, o.oid, 'TRUNCATE') \
+                     ) AS no_write_privileges, \
+                     NOT EXISTS ( \
+                       SELECT 1 FROM schemas AS s \
+                       WHERE has_schema_privilege(current_user, s.oid, 'CREATE') \
+                     ) AS no_create_privileges, \
+                     NOT EXISTS ( \
+                       SELECT 1 \
+                       FROM pg_proc AS p \
+                       JOIN pg_namespace AS n ON n.oid = p.pronamespace \
+                       WHERE n.nspname IN ('public', 'storage') \
+                         AND p.prosecdef \
+                         AND has_function_privilege(current_user, p.oid, 'EXECUTE') \
+                     ) AS no_security_definer_execute \
+            ) \
+            SELECT bool_and( \
+              role_name_matches AND identity_matches AND rolcanlogin \
+              AND no_superuser AND no_createrole AND no_createdb AND no_replication \
+              AND no_bypassrls AND no_write_privileges AND no_create_privileges \
+              AND no_security_definer_execute \
+            ) \
+            FROM role_attrs CROSS JOIN effective_privileges;" \
             "$SUPABASE_READONLY_DATABASE_URL")"
           test "$(printf '%s' "$result" | tr -d '[:space:]')" = 't' || {
             echo "PostgreSQL read-only identity attestation failed" >&2

--- a/.github/workflows/supabase-healthcheck.yml
+++ b/.github/workflows/supabase-healthcheck.yml
@@ -64,6 +64,11 @@ jobs:
                      NOT r.rolreplication AS no_replication, NOT r.rolbypassrls AS no_bypassrls \
               FROM pg_roles AS r \
               WHERE r.rolname = current_user \
+            ), assumable_roles AS ( \
+              SELECT r.rolname, r.rolsuper, r.rolcreaterole, r.rolcreatedb, \
+                     r.rolreplication, r.rolbypassrls \
+              FROM pg_roles AS r \
+              WHERE pg_has_role(current_user, r.oid, 'SET') \
             ), schemas AS ( \
               SELECT n.oid \
               FROM pg_namespace AS n \
@@ -74,6 +79,12 @@ jobs:
               JOIN pg_namespace AS n ON n.oid = c.relnamespace \
               WHERE n.nspname IN ('public', 'storage') \
                 AND c.relkind IN ('r', 'p', 'v', 'f', 'm') \
+            ), sequences AS ( \
+              SELECT c.oid \
+              FROM pg_class AS c \
+              JOIN pg_namespace AS n ON n.oid = c.relnamespace \
+              WHERE n.nspname IN ('public', 'storage') \
+                AND c.relkind = 'S' \
             ), effective_privileges AS ( \
               SELECT NOT EXISTS ( \
                        SELECT 1 FROM objects AS o \
@@ -82,6 +93,11 @@ jobs:
                           OR has_table_privilege(current_user, o.oid, 'DELETE') \
                           OR has_table_privilege(current_user, o.oid, 'TRUNCATE') \
                      ) AS no_write_privileges, \
+                     NOT EXISTS ( \
+                       SELECT 1 FROM sequences AS s \
+                       WHERE has_sequence_privilege(current_user, s.oid, 'USAGE') \
+                          OR has_sequence_privilege(current_user, s.oid, 'UPDATE') \
+                     ) AS no_sequence_write_privileges, \
                      NOT EXISTS ( \
                        SELECT 1 FROM schemas AS s \
                        WHERE has_schema_privilege(current_user, s.oid, 'CREATE') \
@@ -93,13 +109,47 @@ jobs:
                        WHERE n.nspname IN ('public', 'storage') \
                          AND p.prosecdef \
                          AND has_function_privilege(current_user, p.oid, 'EXECUTE') \
-                     ) AS no_security_definer_execute \
+                     ) AS no_security_definer_execute, \
+                     NOT EXISTS ( \
+                       SELECT 1 \
+                       FROM assumable_roles AS ar \
+                       WHERE ar.rolsuper \
+                          OR ar.rolcreaterole \
+                          OR ar.rolcreatedb \
+                          OR ar.rolreplication \
+                          OR ar.rolbypassrls \
+                          OR EXISTS ( \
+                               SELECT 1 FROM objects AS o \
+                               WHERE has_table_privilege(ar.rolname, o.oid, 'INSERT') \
+                                  OR has_table_privilege(ar.rolname, o.oid, 'UPDATE') \
+                                  OR has_table_privilege(ar.rolname, o.oid, 'DELETE') \
+                                  OR has_table_privilege(ar.rolname, o.oid, 'TRUNCATE') \
+                             ) \
+                          OR EXISTS ( \
+                               SELECT 1 FROM sequences AS s \
+                               WHERE has_sequence_privilege(ar.rolname, s.oid, 'USAGE') \
+                                  OR has_sequence_privilege(ar.rolname, s.oid, 'UPDATE') \
+                             ) \
+                          OR EXISTS ( \
+                               SELECT 1 FROM schemas AS s \
+                               WHERE has_schema_privilege(ar.rolname, s.oid, 'CREATE') \
+                             ) \
+                          OR EXISTS ( \
+                               SELECT 1 \
+                               FROM pg_proc AS p \
+                               JOIN pg_namespace AS n ON n.oid = p.pronamespace \
+                               WHERE n.nspname IN ('public', 'storage') \
+                                 AND p.prosecdef \
+                                 AND has_function_privilege(ar.rolname, p.oid, 'EXECUTE') \
+                             ) \
+                     ) AS no_assumable_write_privileges \
             ) \
             SELECT bool_and( \
               role_name_matches AND identity_matches AND rolcanlogin \
               AND no_superuser AND no_createrole AND no_createdb AND no_replication \
-              AND no_bypassrls AND no_write_privileges AND no_create_privileges \
-              AND no_security_definer_execute \
+              AND no_bypassrls AND no_write_privileges AND no_sequence_write_privileges \
+              AND no_create_privileges AND no_security_definer_execute \
+              AND no_assumable_write_privileges \
             ) \
             FROM role_attrs CROSS JOIN effective_privileges;" \
             "$SUPABASE_READONLY_DATABASE_URL")"

--- a/.github/workflows/supabase-healthcheck.yml
+++ b/.github/workflows/supabase-healthcheck.yml
@@ -49,16 +49,26 @@ jobs:
         env:
           SUPABASE_READONLY_DATABASE_URL: ${{ secrets.SUPABASE_READONLY_DATABASE_URL }}
           PGCONNECT_TIMEOUT: '10'
-          PGOPTIONS: '-c default_transaction_read_only=on -c statement_timeout=10000'
+          PGOPTIONS: '-c statement_timeout=10000'
         run: |
           set -euo pipefail
           result="$(timeout --signal=TERM 20s psql \
             --no-psqlrc \
             --set=ON_ERROR_STOP=1 \
             --tuples-only \
-            --command="SELECT current_setting('transaction_read_only') = 'on';" \
+            --command="SELECT current_user = session_user
+              AND r.rolname = current_user
+              AND NOT r.rolsuper
+              AND NOT r.rolbypassrls
+              AND NOT r.rolcreatedb
+              AND NOT r.rolcreaterole
+              AND NOT r.rolreplication
+              AND r.rolinherit
+              AND r.rolcanlogin
+            FROM pg_roles AS r
+            WHERE r.rolname = current_user;" \
             "$SUPABASE_READONLY_DATABASE_URL")"
           test "$(printf '%s' "$result" | tr -d '[:space:]')" = 't' || {
-            echo "PostgreSQL read-only attestation failed" >&2
+            echo "PostgreSQL read-only identity attestation failed" >&2
             exit 1
           }

--- a/.github/workflows/supabase-healthcheck.yml
+++ b/.github/workflows/supabase-healthcheck.yml
@@ -2,7 +2,8 @@ name: Supabase healthcheck
 
 on:
   schedule:
-    - cron: '17 3 * * *'
+    - cron: '0 0 * * *'
+      timezone: 'Asia/Tokyo'
   workflow_dispatch:
 
 permissions:
@@ -21,10 +22,12 @@ jobs:
         env:
           SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          SUPABASE_READONLY_DATABASE_URL: ${{ secrets.SUPABASE_READONLY_DATABASE_URL }}
         run: |
           set -euo pipefail
           test -n "$SUPABASE_URL" || { echo "NEXT_PUBLIC_SUPABASE_URL secret is not configured" >&2; exit 1; }
           test -n "$SUPABASE_ANON_KEY" || { echo "NEXT_PUBLIC_SUPABASE_ANON_KEY secret is not configured" >&2; exit 1; }
+          test -n "$SUPABASE_READONLY_DATABASE_URL" || { echo "SUPABASE_READONLY_DATABASE_URL secret is not configured" >&2; exit 1; }
           case "$SUPABASE_URL" in
             https://*.supabase.co) ;;
             *) echo "NEXT_PUBLIC_SUPABASE_URL must use an https://*.supabase.co URL" >&2; exit 1 ;;
@@ -36,8 +39,26 @@ jobs:
           SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
         run: |
           set -euo pipefail
-          curl --silent --show-error --fail --max-time 10 \
+          curl --silent --show-error --fail --connect-timeout 5 --max-time 15 \
             -H "apikey: $SUPABASE_ANON_KEY" \
             -H "Authorization: Bearer $SUPABASE_ANON_KEY" \
             "$SUPABASE_URL/rest/v1/" \
             >/dev/null
+
+      - name: Attest read-only PostgreSQL access
+        env:
+          SUPABASE_READONLY_DATABASE_URL: ${{ secrets.SUPABASE_READONLY_DATABASE_URL }}
+          PGCONNECT_TIMEOUT: '10'
+          PGOPTIONS: '-c default_transaction_read_only=on -c statement_timeout=10000'
+        run: |
+          set -euo pipefail
+          result="$(timeout --signal=TERM 20s psql \
+            --no-psqlrc \
+            --set=ON_ERROR_STOP=1 \
+            --tuples-only \
+            --command="SELECT current_setting('transaction_read_only') = 'on';" \
+            "$SUPABASE_READONLY_DATABASE_URL")"
+          test "$(printf '%s' "$result" | tr -d '[:space:]')" = 't' || {
+            echo "PostgreSQL read-only attestation failed" >&2
+            exit 1
+          }


### PR DESCRIPTION
## 概要

`1.0.0` に残っている production boundary、read-only healthcheck、scheduler、secret visibility、Time Capsule access boundary の未完了項目を、承認済み scope と安全な証跡に基づいて整理・検証します。Issue #2、#51、#55、#58 は重複する追跡項目を含むため、この Draft PR では実行経路と証跡を一つの review surface に集約します。

production の RLS変更、migration適用、外部scheduler有効化、secret登録・変更、権限変更は、対象 project、実行者、承認scope、rollback方針が独立して確認されるまで実施しません。

## Implementation checklist

- [ ] #2 匿名投稿・アップロード経路の残存権限、healthcheck、scheduler、secret boundary を確認する
- [ ] #51 残存課題の統合管理と最終 scope/review/CI/security gate を完了する
- [ ] #55 Time Capsule production boundary を read-only で検証する
- [ ] #58 PR #52 と関連 Issue の未完了 production task を同期する

## Verification checklist

- [ ] 対象 project と independent read-only identity の権限を確認する
- [ ] RLS、table grants、Storage visibility、RPC execute grants、migration history を read-only で確認する
- [ ] healthcheck の read-only 性、timeout、secret 非公開、failure visibility を確認する
- [ ] production scheduler の責任範囲と実行結果を確認する
- [ ] 証跡、Issue、関連 PR の checklist を同期する
- [x] self-review、lint、typecheck、tests、E2E、build、`git diff --check` を確認する
- [x] production mutation を未承認のまま実行していないことを確認する

## References

Refs #2
Refs #51
Refs #55
Refs #58

## Scope note

この Draft PR は、read-only verification と承認前の実装準備を主対象とします。production data、RLS、Storage policy、scheduler、secret、database grants を変更する作業は別途明示承認が必要です。