### PR TITLE
mainブランチへSupabase healthcheckを同期

### DIFF
--- a/.github/workflows/supabase-healthcheck.yml
+++ b/.github/workflows/supabase-healthcheck.yml
@@ -1,0 +1,159 @@
+name: Supabase healthcheck
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+      timezone: 'Asia/Tokyo'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: supabase-healthcheck
+  cancel-in-progress: true
+
+jobs:
+  readonly-healthcheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Validate Supabase configuration
+        env:
+          SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          SUPABASE_READONLY_DATABASE_URL: ${{ secrets.SUPABASE_READONLY_DATABASE_URL }}
+        run: |
+          set -euo pipefail
+          test -n "$SUPABASE_URL" || { echo "NEXT_PUBLIC_SUPABASE_URL secret is not configured" >&2; exit 1; }
+          test -n "$SUPABASE_ANON_KEY" || { echo "NEXT_PUBLIC_SUPABASE_ANON_KEY secret is not configured" >&2; exit 1; }
+          test -n "$SUPABASE_READONLY_DATABASE_URL" || { echo "SUPABASE_READONLY_DATABASE_URL secret is not configured" >&2; exit 1; }
+          case "$SUPABASE_URL" in
+            https://*.supabase.co) ;;
+            *) echo "NEXT_PUBLIC_SUPABASE_URL must use an https://*.supabase.co URL" >&2; exit 1 ;;
+          esac
+
+      - name: Run read-only REST healthcheck
+        env:
+          SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+        run: |
+          set -euo pipefail
+          curl --silent --show-error --fail --connect-timeout 5 --max-time 15 \
+            -H "apikey: $SUPABASE_ANON_KEY" \
+            -H "Authorization: Bearer $SUPABASE_ANON_KEY" \
+            "$SUPABASE_URL/rest/v1/" \
+            >/dev/null
+
+      - name: Attest read-only PostgreSQL access
+        env:
+          SUPABASE_READONLY_DATABASE_URL: ${{ secrets.SUPABASE_READONLY_DATABASE_URL }}
+          PGCONNECT_TIMEOUT: '10'
+          PGOPTIONS: '-c statement_timeout=10000'
+        run: |
+          set -euo pipefail
+          result="$(timeout --signal=TERM 20s psql \
+            --no-psqlrc \
+            --set=ON_ERROR_STOP=1 \
+            --tuples-only \
+            --command="WITH role_attrs AS ( \
+              SELECT r.rolname = current_user AS role_name_matches, \
+                     current_user = session_user AS identity_matches, \
+                     r.rolcanlogin, NOT r.rolsuper AS no_superuser, \
+                     NOT r.rolcreaterole AS no_createrole, NOT r.rolcreatedb AS no_createdb, \
+                     NOT r.rolreplication AS no_replication, NOT r.rolbypassrls AS no_bypassrls \
+              FROM pg_roles AS r \
+              WHERE r.rolname = current_user \
+            ), assumable_roles AS ( \
+              SELECT r.rolname, r.rolsuper, r.rolcreaterole, r.rolcreatedb, \
+                     r.rolreplication, r.rolbypassrls \
+              FROM pg_roles AS r \
+              WHERE pg_has_role(current_user, r.oid, 'SET') \
+            ), schemas AS ( \
+              SELECT n.oid \
+              FROM pg_namespace AS n \
+              WHERE n.nspname IN ('public', 'storage') \
+            ), objects AS ( \
+              SELECT c.oid \
+              FROM pg_class AS c \
+              JOIN pg_namespace AS n ON n.oid = c.relnamespace \
+              WHERE n.nspname IN ('public', 'storage') \
+                AND c.relkind IN ('r', 'p', 'v', 'f', 'm') \
+            ), sequences AS ( \
+              SELECT c.oid \
+              FROM pg_class AS c \
+              JOIN pg_namespace AS n ON n.oid = c.relnamespace \
+              WHERE n.nspname IN ('public', 'storage') \
+                AND c.relkind = 'S' \
+            ), effective_privileges AS ( \
+              SELECT NOT EXISTS ( \
+                       SELECT 1 FROM objects AS o \
+                       WHERE has_table_privilege(current_user, o.oid, 'INSERT') \
+                          OR has_table_privilege(current_user, o.oid, 'UPDATE') \
+                          OR has_table_privilege(current_user, o.oid, 'DELETE') \
+                          OR has_table_privilege(current_user, o.oid, 'TRUNCATE') \
+                     ) AS no_write_privileges, \
+                     NOT EXISTS ( \
+                       SELECT 1 FROM sequences AS s \
+                       WHERE has_sequence_privilege(current_user, s.oid, 'USAGE') \
+                          OR has_sequence_privilege(current_user, s.oid, 'UPDATE') \
+                     ) AS no_sequence_write_privileges, \
+                     NOT EXISTS ( \
+                       SELECT 1 FROM schemas AS s \
+                       WHERE has_schema_privilege(current_user, s.oid, 'CREATE') \
+                     ) AS no_create_privileges, \
+                     NOT EXISTS ( \
+                       SELECT 1 \
+                       FROM pg_proc AS p \
+                       JOIN pg_namespace AS n ON n.oid = p.pronamespace \
+                       WHERE n.nspname IN ('public', 'storage') \
+                         AND p.prosecdef \
+                         AND has_function_privilege(current_user, p.oid, 'EXECUTE') \
+                     ) AS no_security_definer_execute, \
+                     NOT EXISTS ( \
+                       SELECT 1 \
+                       FROM assumable_roles AS ar \
+                       WHERE ar.rolsuper \
+                          OR ar.rolcreaterole \
+                          OR ar.rolcreatedb \
+                          OR ar.rolreplication \
+                          OR ar.rolbypassrls \
+                          OR EXISTS ( \
+                               SELECT 1 FROM objects AS o \
+                               WHERE has_table_privilege(ar.rolname, o.oid, 'INSERT') \
+                                  OR has_table_privilege(ar.rolname, o.oid, 'UPDATE') \
+                                  OR has_table_privilege(ar.rolname, o.oid, 'DELETE') \
+                                  OR has_table_privilege(ar.rolname, o.oid, 'TRUNCATE') \
+                             ) \
+                          OR EXISTS ( \
+                               SELECT 1 FROM sequences AS s \
+                               WHERE has_sequence_privilege(ar.rolname, s.oid, 'USAGE') \
+                                  OR has_sequence_privilege(ar.rolname, s.oid, 'UPDATE') \
+                             ) \
+                          OR EXISTS ( \
+                               SELECT 1 FROM schemas AS s \
+                               WHERE has_schema_privilege(ar.rolname, s.oid, 'CREATE') \
+                             ) \
+                          OR EXISTS ( \
+                               SELECT 1 \
+                               FROM pg_proc AS p \
+                               JOIN pg_namespace AS n ON n.oid = p.pronamespace \
+                               WHERE n.nspname IN ('public', 'storage') \
+                                 AND p.prosecdef \
+                                 AND has_function_privilege(ar.rolname, p.oid, 'EXECUTE') \
+                             ) \
+                     ) AS no_assumable_write_privileges \
+            ) \
+            SELECT bool_and( \
+              role_name_matches AND identity_matches AND rolcanlogin \
+              AND no_superuser AND no_createrole AND no_createdb AND no_replication \
+              AND no_bypassrls AND no_write_privileges AND no_sequence_write_privileges \
+              AND no_create_privileges AND no_security_definer_execute \
+              AND no_assumable_write_privileges \
+            ) \
+            FROM role_attrs CROSS JOIN effective_privileges;" \
+            "$SUPABASE_READONLY_DATABASE_URL")"
+          test "$(printf '%s' "$result" | tr -d '[:space:]')" = 't' || {
+            echo "PostgreSQL read-only identity attestation failed" >&2
+            exit 1
+          }


### PR DESCRIPTION
## 概要

PR #60 で完成した Supabase healthcheck workflow を default branch `main` に同期します。GitHub Actions の schedule は default branch 上の workflow を基準にするため、production scheduler として daily read-only healthcheck を実行可能にします。

## Implementation checklist

- [x] PR #60 の healthcheck workflow を `main` に同期する

## Verification checklist

- [ ] Self-review of the diff completed
- [ ] CI が成功することを確認する
- [ ] workflow_dispatch で production healthcheck を実行する
- [ ] secret、production data、RLS、Storage、database grants を変更しない

## References

Refs #2
Refs #51
Refs #58
Refs #60

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the Supabase healthcheck workflow to `main` so the daily schedule runs against production. GitHub Actions only runs cron workflows defined on the default branch, so this makes the read-only healthcheck active.

**Workflow behavior**
- Runs daily at midnight Asia/Tokyo and can also be triggered manually with `workflow_dispatch`.
- Validates required secrets and the `NEXT_PUBLIC_SUPABASE_URL` format.
- Performs a read-only REST check against the Supabase API.
- Attests the PostgreSQL connection is read-only, including no write, create, or privileged-role grants through assumable roles.
- Does not modify secrets, production data, RLS policies, Storage, or database grants.

<sup>Written for commit 6f05d26389fc14ad6d202f1745520fd0c5ccf9af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hayato-shino05/Omoide/pull/61?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

