### PR TITLE
refactor: video thumbnail と未使用 export を caller 確認後に整理する

### DIFF
--- a/lib/utils/videoThumbnail.ts
+++ b/lib/utils/videoThumbnail.ts
@@ -47,47 +47,6 @@ export async function generateVideoThumbnail(
 }
 
 /**
- * 動画 URL からサムネイルを生成する
- */
-export async function generateThumbnailFromUrl(
-  videoUrl: string,
-  seekTime: number = 0.5
-): Promise<string | null> {
-  return new Promise((resolve) => {
-    const video = document.createElement('video')
-    const canvas = document.createElement('canvas')
-    const ctx = canvas.getContext('2d')
-
-    video.crossOrigin = 'anonymous'
-    video.preload = 'metadata'
-    video.muted = true
-    video.playsInline = true
-
-    video.onloadedmetadata = () => {
-      video.currentTime = Math.min(seekTime, video.duration)
-    }
-
-    video.onseeked = () => {
-      canvas.width = video.videoWidth
-      canvas.height = video.videoHeight
-
-      if (ctx) {
-        ctx.drawImage(video, 0, 0, canvas.width, canvas.height)
-        resolve(canvas.toDataURL('image/jpeg', 0.8))
-      } else {
-        resolve(null)
-      }
-    }
-
-    video.onerror = () => {
-      resolve(null)
-    }
-
-    video.src = videoUrl
-  })
-}
-
-/**
  * 生成したサムネイルを Supabase ストレージにアップロードする
  */
 export async function uploadThumbnail(


### PR DESCRIPTION
## Summary
`generateVideoThumbnail` 周辺の caller と dynamic import を確認し、未使用と確認できた `generateThumbnailFromUrl` のみを整理しました。実利用中の `generateVideoThumbnail` と `uploadThumbnail`、共有型 `thumbnail_url` は維持しています。

## Target branch
`1.0.0`

## Type
- [ ] Feature
- [ ] Bug fix
- [ ] Hotfix (targeting `main`)
- [x] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Implementation checklist
- [x] Implement #45 — video thumbnail と未使用 export を caller 確認後に整理する

## Verification checklist
- [x] Self-review of the diff completed
- [x] Project's compile-check passes (`npm run typecheck`)
- [x] Lint, format, type-check pass (`npm run lint`, 0 errors; existing coverage warning remains)
- [ ] Tests added or updated for behavior changes (not applicable: export-only cleanup)
- [ ] Docs / `--help` output updated if user-facing (not applicable: internal cleanup)
- [x] No secrets, tokens, or private config in the diff
- [x] No `Co-authored-by: <AI>` or `Generated with …` trailers in commits/comments
- [x] Issue sub-task checklist fully ticked
- [x] CI green (`verify`, Vercel, and Vercel Preview Comments succeeded)

## Test plan
`npm run typecheck`、`npm test`（46 files / 314 tests）、`npm run lint`、`git diff --check` を実行しました。GitNexus は対象 repo index が利用できなかったため、CodeGraph/Serena で caller と impact を確認しました。

## References
Refs #45