### PR TITLE
feat: Omikuji の履歴と streak 方針を決めて実装する

### DIFF
--- a/__tests__/lib/omikujiHistory.test.ts
+++ b/__tests__/lib/omikujiHistory.test.ts
@@ -3,12 +3,27 @@ import {
   appendOmikujiHistory,
   getOmikujiDateKey,
   getOmikujiStreak,
+  OMIKUJI_HISTORY_CONTRACT,
   parseOmikujiHistory,
 } from '@/lib/omikujiHistory'
 
 const fortuneIds = new Set([1, 2, 3])
 
 describe('omikuji history', () => {
+  it('exposes the local-only history contract', () => {
+    expect(OMIKUJI_HISTORY_CONTRACT).toEqual({
+      storage: 'localStorage',
+      storageKey: 'omikuji_history_v1',
+      timezone: 'browser-local',
+      drawsPerDay: 1,
+      allowsRedraw: false,
+      historyLimit: 7,
+      invalidData: 'discard',
+      identity: 'none',
+      sync: 'none',
+    })
+  })
+
   it('uses the browser local day for the history key', () => {
     expect(getOmikujiDateKey(new Date(2026, 0, 1, 0, 1))).toBe('2026-01-01')
   })
@@ -21,6 +36,15 @@ describe('omikuji history', () => {
 
     expect(history).toEqual([{ date: '2026-01-01', fortuneId: 2 }])
     expect(parseOmikujiHistory(JSON.stringify(history), fortuneIds)).toEqual(history)
+  })
+
+  it('limits retained history to seven local days', () => {
+    const history = Array.from({ length: 8 }, (_, index) => ({
+      date: `2026-01-${String(index + 1).padStart(2, '0')}`,
+      fortuneId: 1,
+    }))
+
+    expect(appendOmikujiHistory(history, { date: '2026-01-09', fortuneId: 2 })).toHaveLength(7)
   })
 
   it('recovers safely from malformed or invalid stored data', () => {

--- a/lib/omikujiHistory.ts
+++ b/lib/omikujiHistory.ts
@@ -1,6 +1,19 @@
 export const OMIKUJI_HISTORY_STORAGE_KEY = 'omikuji_history_v1'
 const HISTORY_LIMIT = 7
 
+
+export const OMIKUJI_HISTORY_CONTRACT = {
+  storage: 'localStorage',
+  storageKey: OMIKUJI_HISTORY_STORAGE_KEY,
+  timezone: 'browser-local',
+  drawsPerDay: 1,
+  allowsRedraw: false,
+  historyLimit: HISTORY_LIMIT,
+  invalidData: 'discard',
+  identity: 'none',
+  sync: 'none',
+} as const
+
 export type OmikujiHistoryEntry = {
   date: string
   fortuneId: number


### PR DESCRIPTION
## 概要
Daily Omikuji の history/streak runtime に、公開可能な local-only contract を追加しました。`docs/` は変更せず、identity や Supabase 同期も追加していません。

## 実装範囲
- `localStorage` key は `omikuji_history_v1`
- 日付判定は browser local timezone/day
- 抽選は 1 日 1 回、再抽選なし
- 保持件数は 7 日分
- malformed/invalid data は破棄
- identity と sync は持たない

## Implementation checklist
- [x] #43 の history/streak contract を公開コードと test で固定

## Verification checklist
- [x] `npm run typecheck`
- [x] targeted test: `omikujiHistory.test.ts` 6/6
- [x] full test body: 47 files / 322 tests
- [x] `npm run lint`（0 errors、既存 warning 1 件）
- [x] `git diff --check`
- [x] `docs/`、production database、schema、RLS、Storage policy を変更していない
- [x] AI attribution trailer を含めていない

## Test plan
local day、one draw/day、dedupe、7 日 limit、malformed data、streak、contract invariant を確認しました。pretest の fixture/catalog diagnostics は既存事象として記録しています。

## References
Refs #43

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a public contract for the local-only omikuji history and streak behavior, plus tests that lock it in, satisfying #43's history/streak requirement.

**Behavior**
- Exposes `OMIKUJI_HISTORY_CONTRACT` to document the runtime contract.
- Storage key is `omikuji_history_v1` in `localStorage`.
- Day boundary uses the browser-local timezone; one draw per day with no redraw.
- Retains the latest 7 days; malformed or invalid stored data is discarded.
- No identity or sync; history is purely local.

No migration or rollout steps are needed. Docs, database schema, RLS, and storage policies are unchanged.

<sup>Written for commit 3eca3323fc791d768a724d400ebcdcdc75407ed1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hayato-shino05/Omoide/pull/74?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->







<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR exposes the existing local-only Omikuji history and streak policy as a public immutable contract and adds tests covering that contract and the seven-day retention limit.
- Exports `OMIKUJI_HISTORY_CONTRACT` using the existing storage key and history limit constants.
- Tests the local-only policy, one-draw-per-day semantics, invalid-data handling, and retention behavior.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/omikujiHistory.ts | Adds a typed public contract that accurately describes the existing local history implementation without changing runtime behavior. |
| __tests__/lib/omikujiHistory.test.ts | Adds focused coverage for the exported contract and seven-day history retention. |

</details>

<sub>Reviews (3): Last reviewed commit: ["おみくじ履歴の公開契約を追加"](https://github.com/hayato-shino05/omoide/commit/3eca3323fc791d768a724d400ebcdcdc75407ed1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58810331)</sub>

<!-- /greptile_comment -->