### PR TITLE
fix: Time Capsule招待GETの初回開封記録を追加する

### DIFF
--- a/__tests__/api/time-capsules-id-route.test.ts
+++ b/__tests__/api/time-capsules-id-route.test.ts
@@ -74,4 +74,17 @@ describe('GET /api/time-capsules/[id]', () => {
 
     expect(server.recordFirstOpen).not.toHaveBeenCalled()
   })
+
+  it('returns unlocked invite content when first-open tracking fails', async () => {
+    const data = { id: 1, isUnlocked: true, message: '本文' }
+    server.serializeCapsule.mockResolvedValue(data)
+    server.recordFirstOpen.mockRejectedValue(new Error('database unavailable'))
+
+    const response = await GET(request({ 'x-time-capsule-invite-token': 'a'.repeat(32) }), {
+      params: Promise.resolve({ id: '1' }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ data })
+  })
 })

--- a/__tests__/api/time-capsules-id-route.test.ts
+++ b/__tests__/api/time-capsules-id-route.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const server = vi.hoisted(() => ({
+  createServiceClient: vi.fn(),
+  errorResponse: vi.fn(),
+  findByInviteToken: vi.fn(),
+  parseId: vi.fn(),
+  parseInviteToken: vi.fn(),
+  recordFirstOpen: vi.fn(),
+  requireUser: vi.fn(),
+  serializeCapsule: vi.fn(),
+}))
+
+vi.mock('@/lib/time-capsule/server', () => ({
+  TIME_CAPSULE_SELECT: 'time-capsule-select',
+  TimeCapsuleError: class TimeCapsuleError extends Error {
+    constructor(readonly code: string, readonly status: number, message: string) {
+      super(message)
+    }
+  },
+  ...server,
+}))
+
+import { GET } from '@/app/api/time-capsules/[id]/route'
+
+function request(headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest('http://localhost/api/time-capsules/1', { headers })
+}
+
+const row = { id: 1, invite_revoked_at: null }
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  server.parseId.mockReturnValue(1)
+  server.parseInviteToken.mockReturnValue('a'.repeat(32))
+  server.findByInviteToken.mockResolvedValue({ client: {}, row })
+  server.recordFirstOpen.mockResolvedValue(true)
+  server.serializeCapsule.mockResolvedValue({ id: 1, isUnlocked: false })
+  server.errorResponse.mockImplementation((error: { code?: string; status?: number }) =>
+    Response.json({ error: { code: error.code ?? 'internal_error' } }, { status: error.status ?? 500 })
+  )
+})
+
+describe('GET /api/time-capsules/[id]', () => {
+  it('records the first open for an unlocked invite access', async () => {
+    const data = { id: 1, isUnlocked: true, message: '本文' }
+    server.serializeCapsule.mockResolvedValue(data)
+
+    const response = await GET(request({ 'x-time-capsule-invite-token': 'a'.repeat(32) }), {
+      params: Promise.resolve({ id: '1' }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(server.recordFirstOpen).toHaveBeenCalledWith({}, row)
+    expect(await response.json()).toEqual({ data })
+  })
+
+  it('does not record a sealed invite access', async () => {
+    await GET(request({ 'x-time-capsule-invite-token': 'a'.repeat(32) }), {
+      params: Promise.resolve({ id: '1' }),
+    })
+
+    expect(server.recordFirstOpen).not.toHaveBeenCalled()
+  })
+
+  it('does not record an owner view', async () => {
+    const from = vi.fn(() => ({ select: vi.fn(() => ({ eq: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: vi.fn().mockResolvedValue({ data: row, error: null }) })) })) })) }))
+    server.requireUser.mockResolvedValue({ user: { id: 'owner-1' } })
+    server.createServiceClient.mockReturnValue({ from })
+    server.serializeCapsule.mockResolvedValue({ id: 1, isUnlocked: true, message: '本文' })
+
+    await GET(request(), { params: Promise.resolve({ id: '1' }) })
+
+    expect(server.recordFirstOpen).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/time-capsules/[id]/route.ts
+++ b/app/api/time-capsules/[id]/route.ts
@@ -6,6 +6,7 @@ import {
   findByInviteToken,
   parseId,
   parseInviteToken,
+  recordFirstOpen,
   requireUser,
   serializeCapsule,
   createServiceClient,
@@ -21,8 +22,18 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const inviteToken = request.headers.get('x-time-capsule-invite-token')
     if (inviteToken) {
       const { client, row } = await findByInviteToken(parseInviteToken(inviteToken), id)
+      const data = await serializeCapsule(client, row)
+      if (data.isUnlocked === true) {
+        try {
+          await recordFirstOpen(client, row)
+        } catch (error) {
+          console.warn('[TimeCapsule] first-open tracking failed', {
+            error: error instanceof Error ? error.name : 'unknown_error',
+          })
+        }
+      }
       return Response.json(
-        { data: await serializeCapsule(client, row) },
+        { data },
         { headers: { 'Cache-Control': 'no-store', 'Referrer-Policy': 'no-referrer' } }
       )
     }


### PR DESCRIPTION
## 概要

招待トークンを使う `GET /api/time-capsules/[id]` で、解禁済みの capsule を返す際に first-open tracking を記録するよう修正しました。
tracking の保存に失敗しても、認可済みの content 配信は継続します。

## 原因と影響

invite-token の `GET` 経路は `findByInviteToken` と `serializeCapsule` の後、そのまま response を返していました。
そのため、`POST` access 経路と異なり、解禁済み content を返しても `opened_at` が記録されませんでした。

## Implementation checklist
- [x] invite-token `GET` の first-open tracking を追加する
- [x] tracking failure が content 配信を妨げないことを確認する
- [x] owner `GET` と sealed capsule が tracking されないことを確認する

## Verification checklist
- [x] targeted Time Capsule tests: 4 tests
- [x] `npm run typecheck`
- [x] `npm run lint`（0 errors、既存 warning 1 件）
- [x] `npm run build`
- [x] `git diff --check`
- [x] CI と review thread の最終確認
- [x] production migration、schema、RLS、Storage policy、tracking activation を実行していない

## 未検証・範囲外

identity、recipient/link boundary、retention cleanup、production schema/RLS/API verification はこのPRの範囲外です。
invite token と access code は bearer credential のままで、recipient binding を追加していません。

## Test plan

unlocked invite GET が `recordFirstOpen` を呼ぶこと、sealed invite GET と owner GET が呼ばないこと、tracking error 後も content を返すことを確認します。

## References
Refs #44

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds first-open tracking to unlocked Time Capsule invite-token GET requests while preserving content delivery if tracking fails.
- Serializes authorized invite content before attempting first-open persistence.
- Records first-open state only for unlocked invite-token access.
- Adds coverage for unlocked, sealed, owner, and tracking-failure paths.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/api/time-capsules/[id]/route.ts | Adds best-effort first-open persistence for unlocked invite-token GET responses without changing owner or sealed-capsule behavior. |
| __tests__/api/time-capsules-id-route.test.ts | Covers tracking eligibility and verifies that persistence failure does not block authorized content delivery. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant GET as Invite GET route
    participant Capsule as Capsule service
    participant Tracking as First-open tracking
    Client->>GET: GET with invite token
    GET->>Capsule: Find and serialize capsule
    Capsule-->>GET: Authorized capsule data
    alt Capsule is unlocked
        GET->>Tracking: Record first open
        alt Tracking fails
            Tracking--xGET: Error logged
        else Tracking succeeds
            Tracking-->>GET: Recorded or already opened
        end
    end
    GET-->>Client: Capsule data
```
</details>

<sub>Reviews (2): Last reviewed commit: ["招待GETのtracking失敗回帰テストを追加"](https://github.com/hayato-shino05/omoide/commit/16054c1a4c2559b9583fff21efea042a875eb16f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58820596)</sub>

<!-- /greptile_comment -->