### PR TITLE
fix: 掲示板メディア投稿を正規アップロード経路へ統一する

### DIFF
--- a/__tests__/components/ContributorPromptButtons.test.tsx
+++ b/__tests__/components/ContributorPromptButtons.test.tsx
@@ -90,4 +90,25 @@ describe('Contributor prompts', () => {
     await waitFor(() => expect(uploadCommunityMedia).toHaveBeenCalledWith({ file, sender: '花子' }))
     expect(onSubmit).toHaveBeenCalledWith('花子', 'おめでとう！', undefined, 'images/post.png')
   })
+
+  it('rejects unsupported post media before upload', () => {
+    render(<PostForm onSubmit={vi.fn()} />)
+    const file = new File(['audio'], 'post.mp3', { type: 'audio/mpeg' })
+
+    fireEvent.change(document.querySelector('input[type="file"]') as HTMLInputElement, { target: { files: [file] } })
+
+    expect(screen.getByText('fileTypeError')).toBeInTheDocument()
+    expect(uploadCommunityMedia).not.toHaveBeenCalled()
+  })
+
+  it('rejects post media larger than the canonical 50MB limit', () => {
+    render(<PostForm onSubmit={vi.fn()} />)
+    const file = new File(['image'], 'post.png', { type: 'image/png' })
+    Object.defineProperty(file, 'size', { value: 50 * 1024 * 1024 + 1 })
+
+    fireEvent.change(document.querySelector('input[type="file"]') as HTMLInputElement, { target: { files: [file] } })
+
+    expect(screen.getByText('fileTooLargeWithLimit')).toBeInTheDocument()
+    expect(uploadCommunityMedia).not.toHaveBeenCalled()
+  })
 })

--- a/__tests__/components/ContributorPromptButtons.test.tsx
+++ b/__tests__/components/ContributorPromptButtons.test.tsx
@@ -1,9 +1,10 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { MessageForm } from '@/components/community/MessageForm'
 import PostForm from '@/components/community/PostForm'
 
 const sendMessage = vi.fn()
+const uploadCommunityMedia = vi.hoisted(() => vi.fn())
 
 vi.mock('@/lib/i18n/LanguageContext', () => ({
   useLanguage: () => ({
@@ -24,7 +25,7 @@ vi.mock('@/components/ui/Icon', () => ({
 }))
 
 vi.mock('@/lib/supabase/communityMedia', () => ({
-  uploadCommunityMedia: vi.fn(),
+  uploadCommunityMedia,
 }))
 
 vi.mock('@/lib/supabase/client', () => ({
@@ -33,6 +34,7 @@ vi.mock('@/lib/supabase/client', () => ({
 
 beforeEach(() => {
   sendMessage.mockReset()
+  uploadCommunityMedia.mockReset()
   localStorage.clear()
 })
 
@@ -72,5 +74,20 @@ describe('Contributor prompts', () => {
     fireEvent.click(prompt)
     expect(textarea).toHaveValue('既存の投稿')
     expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('uploads post media through the canonical community media helper', async () => {
+    uploadCommunityMedia.mockResolvedValue({ object_path: 'images/post.png' })
+    const onSubmit = vi.fn().mockResolvedValue(true)
+    render(<PostForm onSubmit={onSubmit} />)
+
+    fireEvent.change(screen.getByPlaceholderText('yourName'), { target: { value: '花子' } })
+    fireEvent.change(screen.getByPlaceholderText('typeMessage'), { target: { value: 'おめでとう！' } })
+    const file = new File(['image'], 'post.png', { type: 'image/png' })
+    fireEvent.change(document.querySelector('input[type="file"]') as HTMLInputElement, { target: { files: [file] } })
+    fireEvent.click(screen.getByRole('button', { name: 'postMessage' }))
+
+    await waitFor(() => expect(uploadCommunityMedia).toHaveBeenCalledWith({ file, sender: '花子' }))
+    expect(onSubmit).toHaveBeenCalledWith('花子', 'おめでとう！', undefined, 'images/post.png')
   })
 })

--- a/__tests__/components/ContributorPromptButtons.test.tsx
+++ b/__tests__/components/ContributorPromptButtons.test.tsx
@@ -91,6 +91,22 @@ describe('Contributor prompts', () => {
     expect(onSubmit).toHaveBeenCalledWith('花子', 'おめでとう！', undefined, 'images/post.png')
   })
 
+  it('accepts codec-qualified camera video MIME after normalization', async () => {
+    uploadCommunityMedia.mockResolvedValue({ object_path: 'videos/post.webm' })
+    const onSubmit = vi.fn().mockResolvedValue(true)
+    render(<PostForm onSubmit={onSubmit} />)
+
+    fireEvent.change(screen.getByPlaceholderText('yourName'), { target: { value: '花子' } })
+    fireEvent.change(screen.getByPlaceholderText('typeMessage'), { target: { value: '動画です' } })
+    const file = new File(['video'], 'post.webm', { type: 'video/webm;codecs=vp9' })
+    fireEvent.change(document.querySelector('input[type="file"]') as HTMLInputElement, { target: { files: [file] } })
+    fireEvent.click(screen.getByRole('button', { name: 'postMessage' }))
+
+    await waitFor(() => expect(uploadCommunityMedia).toHaveBeenCalled())
+    expect(uploadCommunityMedia.mock.calls[0][0].file.type).toBe('video/webm')
+    expect(onSubmit).toHaveBeenCalledWith('花子', '動画です', undefined, 'videos/post.webm')
+  })
+
   it('rejects unsupported post media before upload', () => {
     render(<PostForm onSubmit={vi.fn()} />)
     const file = new File(['audio'], 'post.mp3', { type: 'audio/mpeg' })

--- a/components/community/PostForm.tsx
+++ b/components/community/PostForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect } from 'react'
 import { uploadCommunityMedia } from '@/lib/supabase/communityMedia'
+import { getMediaKind, validateCommunityMediaFile } from '@/lib/validations/upload'
 import { CameraCapture } from './CameraCapture'
 import { ContributorPromptButtons } from './ContributorPromptButtons'
 import { Icon } from '@/components/ui/Icon'
@@ -38,17 +39,11 @@ export default function PostForm({ onSubmit }: PostFormProps) {
     const file = e.target.files?.[0]
     if (!file) return
 
-    const isImage = file.type.startsWith('image/')
-    const isVideo = file.type.startsWith('video/')
-    
-    if (!isImage && !isVideo) {
-      setError(t('fileTypeError'))
-      return
-    }
-
-    const maxSize = isVideo ? 100 * 1024 * 1024 : 50 * 1024 * 1024
-    if (file.size > maxSize) {
-      setError(t('fileTooLargeWithLimit', { size: isVideo ? 100 : 50 }))
+    const validation = validateCommunityMediaFile(file)
+    if (!validation.valid || getMediaKind(file.type) === 'audio') {
+      setError(!validation.valid && file.size > 50 * 1024 * 1024
+        ? t('fileTooLargeWithLimit', { size: 50 })
+        : t('fileTypeError'))
       return
     }
 

--- a/components/community/PostForm.tsx
+++ b/components/community/PostForm.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useRef, useEffect } from 'react'
-import { getSupabase } from '@/lib/supabase/client'
+import { uploadCommunityMedia } from '@/lib/supabase/communityMedia'
 import { CameraCapture } from './CameraCapture'
 import { ContributorPromptButtons } from './ContributorPromptButtons'
 import { Icon } from '@/components/ui/Icon'
@@ -69,20 +69,10 @@ export default function PostForm({ onSubmit }: PostFormProps) {
 
   const uploadFile = async (file: File): Promise<string | null> => {
     try {
-      const supabase = getSupabase()
-      const isVideo = file.type.startsWith('video/')
-      const bucket = isVideo ? 'video' : 'media'
-      const ext = file.name.split('.').pop()
-      const fileName = `${isVideo ? 'video' : 'image'}_${Date.now()}.${ext}`
-
       setUploadProgress(10)
-      const { error: uploadError } = await supabase.storage.from(bucket).upload(fileName, file)
-      if (uploadError) throw uploadError
-
-      setUploadProgress(80)
-      const { data: urlData } = supabase.storage.from(bucket).getPublicUrl(fileName)
+      const data = await uploadCommunityMedia({ file, sender: author })
       setUploadProgress(100)
-      return urlData.publicUrl
+      return data.object_path
     } catch (err) {
       console.error('Upload error:', err)
       return null

--- a/components/community/PostForm.tsx
+++ b/components/community/PostForm.tsx
@@ -35,22 +35,25 @@ export default function PostForm({ onSubmit }: PostFormProps) {
   const [cameraMode, setCameraMode] = useState<'photo' | 'video'>('photo')
   const fileInputRef = useRef<HTMLInputElement>(null)
 
-  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0]
-    if (!file) return
-
+  const handleSelectedFile = (file: File): boolean => {
     const validation = validateCommunityMediaFile(file)
     if (!validation.valid || getMediaKind(file.type) === 'audio') {
       setError(!validation.valid && file.size > 50 * 1024 * 1024
         ? t('fileTooLargeWithLimit', { size: 50 })
         : t('fileTypeError'))
-      return
+      return false
     }
 
     setSelectedFile(file)
     setError(null)
     if (previewUrl) URL.revokeObjectURL(previewUrl)
     setPreviewUrl(URL.createObjectURL(file))
+    return true
+  }
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) handleSelectedFile(file)
   }
 
   const removeFile = () => {
@@ -185,7 +188,7 @@ export default function PostForm({ onSubmit }: PostFormProps) {
           <ContributorPromptButtons hasContent={content.trim().length > 0} onSelect={setContent} />
 
           {/* メディアアップロード */}
-          <input ref={fileInputRef} type="file" accept="image/*,video/*" onChange={handleFileSelect} style={{ display: 'none' }} />
+          <input ref={fileInputRef} type="file" accept="image/jpeg,image/png,image/webp,image/gif,video/mp4,video/webm" onChange={handleFileSelect} style={{ display: 'none' }} />
           
           {!selectedFile ? (
             <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
@@ -255,9 +258,7 @@ export default function PostForm({ onSubmit }: PostFormProps) {
         <CameraCapture
           mode={cameraMode}
           onCapture={(file) => {
-            setSelectedFile(file)
-            if (previewUrl) URL.revokeObjectURL(previewUrl)
-            setPreviewUrl(URL.createObjectURL(file))
+            handleSelectedFile(file)
             setShowCamera(false)
           }}
           onClose={() => setShowCamera(false)}

--- a/components/community/PostForm.tsx
+++ b/components/community/PostForm.tsx
@@ -35,19 +35,26 @@ export default function PostForm({ onSubmit }: PostFormProps) {
   const [cameraMode, setCameraMode] = useState<'photo' | 'video'>('photo')
   const fileInputRef = useRef<HTMLInputElement>(null)
 
+  const normalizeMediaFile = (file: File): File => {
+    const baseMimeType = file.type.split(';', 1)[0].trim().toLowerCase()
+    if (baseMimeType === file.type) return file
+    return new File([file], file.name, { type: baseMimeType, lastModified: file.lastModified })
+  }
+
   const handleSelectedFile = (file: File): boolean => {
-    const validation = validateCommunityMediaFile(file)
-    if (!validation.valid || getMediaKind(file.type) === 'audio') {
+    const normalizedFile = normalizeMediaFile(file)
+    const validation = validateCommunityMediaFile(normalizedFile)
+    if (!validation.valid || getMediaKind(normalizedFile.type) === 'audio') {
       setError(!validation.valid && file.size > 50 * 1024 * 1024
         ? t('fileTooLargeWithLimit', { size: 50 })
         : t('fileTypeError'))
       return false
     }
 
-    setSelectedFile(file)
+    setSelectedFile(normalizedFile)
     setError(null)
     if (previewUrl) URL.revokeObjectURL(previewUrl)
-    setPreviewUrl(URL.createObjectURL(file))
+    setPreviewUrl(URL.createObjectURL(normalizedFile))
     return true
   }
 
@@ -68,7 +75,7 @@ export default function PostForm({ onSubmit }: PostFormProps) {
   const uploadFile = async (file: File): Promise<string | null> => {
     try {
       setUploadProgress(10)
-      const data = await uploadCommunityMedia({ file, sender: author })
+      const data = await uploadCommunityMedia({ file: normalizeMediaFile(file), sender: author })
       setUploadProgress(100)
       return data.object_path
     } catch (err) {


### PR DESCRIPTION
## 概要

`PostForm` のメディア投稿を `uploadCommunityMedia` に統一しました。
旧 `media` / `video` bucket への直接 upload をやめ、canonical な `community-media` 経路で保存した `object_path` を投稿 metadata に渡します。

## 原因と影響

`PostForm` は旧 upload 経路を保持し、canonical helper と MIME/size の契約も一致していませんでした。現在は file picker と `CameraCapture` の両方が同じ validation boundary を通り、codec-qualified video MIME も base MIME に正規化します。

## Implementation checklist
- [x] `PostForm` が `uploadCommunityMedia` を使うよう統一する
- [x] 投稿 metadata に canonical `object_path` を渡す
- [x] canonical upload caller の regression test を追加する

## Verification checklist
- [x] targeted tests: codec-qualified MIME を含む 7 tests
- [x] `npm run typecheck`
- [x] `npm run lint`（0 errors、既存 warning 1 件）
- [x] `npm run build`
- [x] `git diff --check`
- [x] CI `verify` success
- [x] Vercel Preview success
- [x] Greptile review success、既存 review threads は resolved / outdated
- [x] production RLS、Storage policy、migration、scheduler、secret は変更していない

## 未検証・範囲外

production の `storage.objects` policy、bucket visibility、rate limit、独立 read-only catalog は未検証です。
`messages.media_object_path` の path validation、gift payload validation、server upload、orphan object cleanup は別 work unit とし、このPRでは変更しません。
匿名 upload を `community-media` 以外の bucket に許可するかどうかも未決定です。

## Test plan

`PostForm` の selected file upload が `uploadCommunityMedia({ file, sender })` を呼び、返された `object_path` を `onSubmit` に渡すことを確認します。MIME allowlist 外、50 MiB 超過、codec-qualified video MIME の各境界も確認します。

## References
Refs #2

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR routes bulletin-board media through the canonical community-media upload path and passes the resulting object path into post metadata.
- Normalizes codec-qualified video MIME values before validation and upload.
- Applies the canonical MIME allowlist and 50 MiB limit to picker and camera files.
- Adds regression coverage for canonical upload, object-path forwarding, MIME normalization, and rejection boundaries.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| components/community/PostForm.tsx | Replaces legacy bucket uploads with the canonical helper and consistently validates and normalizes selected or captured media. |
| __tests__/components/ContributorPromptButtons.test.tsx | Adds focused regression coverage for canonical PostForm uploads and supported validation boundaries. |

</details>

<sub>Reviews (4): Last reviewed commit: ["動画 MIME の codec 付き入力を正規化"](https://github.com/hayato-shino05/omoide/commit/4dccd87f698cb73a56ff14872ff6a91b2e5629e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58837350)</sub>

<!-- /greptile_comment -->