### PR TITLE
Time Capsule開封トラッキングのプライバシー契約を明文化する

### DIFF
--- a/docs/time-capsule-open-tracking-contract.md
+++ b/docs/time-capsule-open-tracking-contract.md
@@ -2,7 +2,7 @@
 
 ## 対象
 
-Open tracking は、invite token を使った認可済みの Time Capsule access に限定します。対象は解禁済み capsule の first open です。
+Open tracking は、invite token または access code を使った認可済みの Time Capsule access に限定します。対象は解禁済み capsule の first open です。
 
 - owner access は対象外です。
 - 未解禁 capsule は対象外です。
@@ -11,7 +11,7 @@ Open tracking は、invite token を使った認可済みの Time Capsule access
 
 ## Identity と recipient boundary
 
-invite token は bearer credential です。token の保有者を個人 identity として登録したり、recipient を推定したりしません。tracking の対象境界は、既存の invite token によって認可された capsule 1 件です。
+invite token と access code は bearer credential です。credential の保有者を個人 identity として登録したり、recipient を推定したりしません。tracking の対象境界は、既存の credential によって認可された capsule 1 件です。
 
 別の利用者、別の capsule、recipient の連絡先、IP address、user agent、device fingerprint は tracking record に保存しません。
 
@@ -29,6 +29,6 @@ tracking は capsule row の `opened_at` に限定します。独立した event
 
 ## 実装と検証
 
-実装は `recordFirstOpen` と既存の Time Capsule access route を再利用します。unlocked invite GET、sealed invite GET、owner GET、tracking failure、duplicate first open を regression test で確認します。
+実装は `recordFirstOpen` と既存の Time Capsule access route（POST）を再利用します。unlocked invite access、unlocked access code、sealed access、owner access、tracking failure、duplicate first open を既存の regression test で確認します。invite-token の通常 GET は `recordFirstOpen` を呼ばないため、tracking 対象外です。
 
 Production schema、RLS、API の検証は repository test とは別の production read-only evidence が必要です。

--- a/docs/time-capsule-open-tracking-contract.md
+++ b/docs/time-capsule-open-tracking-contract.md
@@ -1,0 +1,34 @@
+# Time Capsule Open Tracking Contract
+
+## 対象
+
+Open tracking は、invite token を使った認可済みの Time Capsule access に限定します。対象は解禁済み capsule の first open です。
+
+- owner access は対象外です。
+- 未解禁 capsule は対象外です。
+- invite token 以外の識別子から recipient や identity を推測しません。
+- reminder delivery とは別の処理として扱います。
+
+## Identity と recipient boundary
+
+invite token は bearer credential です。token の保有者を個人 identity として登録したり、recipient を推定したりしません。tracking の対象境界は、既存の invite token によって認可された capsule 1 件です。
+
+別の利用者、別の capsule、recipient の連絡先、IP address、user agent、device fingerprint は tracking record に保存しません。
+
+## 保存データ
+
+初回開封時に `opened_at` だけを記録します。既存値がある場合は更新せず、同じ capsule の再アクセスで新しい open event を作成しません。
+
+`opened_at` は UTC timestamp として保存します。content 配信に必要な認可済みデータと tracking metadata は分離し、tracking の保存失敗で認可済み content の配信を失敗させません。
+
+## Retention と削除
+
+tracking は capsule row の `opened_at` に限定します。独立した event log、PII、アクセス履歴、bearer token の plaintext は保存しません。capsule の所有者が capsule を削除または revoke した場合、`opened_at` も同じ row の削除・管理境界に従います。
+
+個別の open event の export、notification、reminder delivery はこの contract の対象外です。
+
+## 実装と検証
+
+実装は `recordFirstOpen` と既存の Time Capsule access route を再利用します。unlocked invite GET、sealed invite GET、owner GET、tracking failure、duplicate first open を regression test で確認します。
+
+Production schema、RLS、API の検証は repository test とは別の production read-only evidence が必要です。

--- a/docs/time-capsule-open-tracking-contract.md
+++ b/docs/time-capsule-open-tracking-contract.md
@@ -29,6 +29,6 @@ tracking は capsule row の `opened_at` に限定します。独立した event
 
 ## 実装と検証
 
-実装は `recordFirstOpen` と既存の Time Capsule access route（POST）を再利用します。unlocked invite access、unlocked access code、sealed access、owner access、tracking failure、duplicate first open を既存の regression test で確認します。invite-token の通常 GET は `recordFirstOpen` を呼ばないため、tracking 対象外です。
+実装は `recordFirstOpen` と既存の Time Capsule access route（POST）を再利用します。既存の regression test は tracking failure 時の content 配信維持と、`recordFirstOpen` が `opened_at` が null の capsule のみ更新するクエリ形状を確認します。unlocked invite access の成功時に `recordFirstOpen` が呼ばれる点、owner access および sealed access で first open が記録されない点、duplicate first open 時の再アクセス無視は未検証です。invite-token の通常 GET は `recordFirstOpen` を呼ばないため、tracking 対象外です。
 
 Production schema、RLS、API の検証は repository test とは別の production read-only evidence が必要です。


### PR DESCRIPTION
## 概要

Time Capsule の first-open tracking について、既存の認可境界と保存データを文書化しました。既存の PR #75 の実装を変更せず、invite token を使った unlocked access に限定する契約を追加しています。

## 変更内容

- 対象を authorized unlocked invite-token access の first open に限定
- owner access、sealed capsule、推測による identity/recipient を対象外に設定
- 保存データを UTC の `opened_at` に限定
- PII、bearer token plaintext、独立 event log を保存しない方針を明記
- capsule row の削除・revoke 境界と retention 方針を記録
- tracking failure が content delivery を妨げず、reminder delivery と分離されることを明記

## 検証

- `npm run typecheck` pass
- Time Capsule route tests 2件 pass
- `npm run lint` pass
- `npm run build` pass
- `git diff --check` pass
- `gitnexus detect_changes` で変更は文書ファイル1件、risk low を確認

## 未検証

Production schema、RLS、API の確認には独立した production read-only evidence が必要です。この PR は production migration、schema、RLS、Storage policy を変更しません。

## References

Refs #44

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a privacy contract doc for Time Capsule first-open tracking that codifies existing boundaries without changing implementation. Tracking covers authorized unlocked access via invite token or access code (POST route) and stores only `opened_at` in UTC; owner access, sealed capsules, identity inference, PII, token plaintext, and standalone event logs are out of scope, and tracking failures don't affect content or reminder delivery. The normal invite-token GET doesn't record opens. Also documents the verification boundary: regression tests cover delivery safety and the null-only `opened_at` update, while unlocked-access invocation, owner/sealed non-recording, duplicate re-access, and production schema/RLS/API need separate read-only evidence. Addresses #44 and doesn't change production schema, RLS, or storage policies.

<sup>Written for commit 6cb9368c5b01f73cb03e9c05adc27ce4b7415eb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hayato-shino05/Omoide/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR documents the privacy and lifecycle contract for Time Capsule first-open tracking without changing runtime behavior.
- Limits tracking to authorized, unlocked invite-token or access-code access.
- Restricts persisted tracking metadata to the capsule row’s UTC `opened_at`.
- Documents identity, retention, deletion, failure-isolation, and verification boundaries.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/time-capsule-open-tracking-contract.md | Documents the existing tracking boundary and now accurately distinguishes tracked POST access from the untracked invite-token GET route while precisely describing current regression coverage. |

</details>

<sub>Reviews (3): Last reviewed commit: ["レビュー指摘に合わせて検証範囲を明記"](https://github.com/hayato-shino05/omoide/commit/6cb9368c5b01f73cb03e9c05adc27ce4b7415eb8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59158606)</sub>

<!-- /greptile_comment -->