### PR TITLE
匿名投稿の本番レート制限案を追加する

### DIFF
--- a/__tests__/api/community-route.test.ts
+++ b/__tests__/api/community-route.test.ts
@@ -84,13 +84,16 @@ describe('POST /api/community', () => {
     expect(server.createServiceClient).not.toHaveBeenCalled()
   })
 
-  it('rejects overlong filenames before uploading media', async () => {
+  it('rejects blank or overlong filenames before uploading media', async () => {
     const { upload } = makeClient()
+    const blankName = new File(['image'], '   ', { type: 'image/png' })
     const longName = new File(['image'], `${'a'.repeat(252)}.png`, { type: 'image/png' })
 
-    const response = await POST(request({ kind: 'message', sender: '花子', content: '本文' }, longName))
+    const blankNameResponse = await POST(request({ kind: 'message', sender: '花子', content: '本文' }, blankName))
+    const longNameResponse = await POST(request({ kind: 'message', sender: '花子', content: '本文' }, longName))
 
-    expect(response.status).toBe(400)
+    expect(blankNameResponse.status).toBe(400)
+    expect(longNameResponse.status).toBe(400)
     expect(upload).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/api/community-route.test.ts
+++ b/__tests__/api/community-route.test.ts
@@ -24,6 +24,13 @@ function request(fields: Record<string, string>, file?: File) {
   return new NextRequest('http://localhost/api/community', { method: 'POST', body })
 }
 
+function requestWithFormData(fields: Record<string, string>, file: File) {
+  const body = new FormData()
+  Object.entries(fields).forEach(([key, value]) => body.set(key, value))
+  body.set('media', file)
+  return { formData: async () => body } as unknown as NextRequest
+}
+
 beforeEach(() => vi.resetAllMocks())
 
 describe('POST /api/community', () => {
@@ -51,5 +58,38 @@ describe('POST /api/community', () => {
 
     expect(response.status).toBe(400)
     expect(server.createServiceClient).not.toHaveBeenCalled()
+  })
+
+  it('rejects overlong optional fields instead of silently dropping them', async () => {
+    makeClient()
+    const birthdayPersonResponse = await POST(request({
+      kind: 'message',
+      sender: '花子',
+      content: '本文',
+      birthdayPerson: 'あ'.repeat(101),
+    }))
+    const descriptionResponse = await POST(request({
+      kind: 'post',
+      sender: '花子',
+      content: '本文',
+      description: 'あ'.repeat(1001),
+    }))
+
+    expect(birthdayPersonResponse.status).toBe(400)
+    expect(descriptionResponse.status).toBe(400)
+    expect(server.createServiceClient).not.toHaveBeenCalled()
+  })
+
+  it('rejects invalid filenames before uploading media', async () => {
+    const { upload } = makeClient()
+    const blankName = new File(['image'], '   ', { type: 'image/png' })
+    const longName = new File(['image'], `${'a'.repeat(252)}.png`, { type: 'image/png' })
+
+    const blankNameResponse = await POST(requestWithFormData({ kind: 'message', sender: '花子', content: '本文' }, blankName))
+    const longNameResponse = await POST(requestWithFormData({ kind: 'message', sender: '花子', content: '本文' }, longName))
+
+    expect(blankNameResponse.status).toBe(400)
+    expect(longNameResponse.status).toBe(400)
+    expect(upload).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/api/community-route.test.ts
+++ b/__tests__/api/community-route.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const server = vi.hoisted(() => ({ createServiceClient: vi.fn() }))
+vi.mock('@/lib/time-capsule/server', () => server)
+
+import { POST } from '@/app/api/community/route'
+
+function makeClient(rpcResult: { data: unknown; error: Error | null } = { data: { message: { id: 1 } }, error: null }) {
+  const remove = vi.fn().mockResolvedValue({ error: null })
+  const upload = vi.fn().mockResolvedValue({ error: null })
+  const client = {
+    rpc: vi.fn().mockResolvedValue(rpcResult),
+    storage: { from: vi.fn(() => ({ upload, remove })) },
+  }
+  server.createServiceClient.mockReturnValue(client)
+  return { client, upload, remove }
+}
+
+function request(fields: Record<string, string>, file?: File) {
+  const body = new FormData()
+  Object.entries(fields).forEach(([key, value]) => body.set(key, value))
+  if (file) body.set('media', file)
+  return new NextRequest('http://localhost/api/community', { method: 'POST', body })
+}
+
+beforeEach(() => vi.resetAllMocks())
+
+describe('POST /api/community', () => {
+  it('uploads media and creates a message through the fixed RPC', async () => {
+    const { client, upload } = makeClient()
+    const response = await POST(request({ kind: 'message', sender: '花子', content: 'おめでとう' }, new File(['image'], 'cake.png', { type: 'image/png' })))
+
+    expect(response.status).toBe(201)
+    expect(upload).toHaveBeenCalledOnce()
+    expect(client.rpc).toHaveBeenCalledWith('create_community_submission', expect.objectContaining({ p_kind: 'message', p_object_path: expect.stringMatching(/^images\//) }))
+  })
+
+  it('removes uploaded media when the RPC fails and returns a safe error', async () => {
+    const { remove } = makeClient({ data: null, error: new Error('database detail') })
+    const response = await POST(request({ kind: 'post', sender: '花子', content: '本文' }, new File(['image'], 'cake.png', { type: 'image/png' })))
+
+    expect(response.status).toBe(500)
+    expect(remove).toHaveBeenCalledOnce()
+    await expect(response.json()).resolves.toEqual({ error: '投稿を送信できません' })
+  })
+
+  it('rejects unsupported input before creating a service client', async () => {
+    makeClient()
+    const response = await POST(request({ kind: 'message', sender: '', content: '本文' }))
+
+    expect(response.status).toBe(400)
+    expect(server.createServiceClient).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/api/community-route.test.ts
+++ b/__tests__/api/community-route.test.ts
@@ -21,13 +21,6 @@ function request(fields: Record<string, string>, file?: File) {
   const body = new FormData()
   Object.entries(fields).forEach(([key, value]) => body.set(key, value))
   if (file) body.set('media', file)
-  return new NextRequest('http://localhost/api/community', { method: 'POST', body })
-}
-
-function requestWithFormData(fields: Record<string, string>, file: File) {
-  const body = new FormData()
-  Object.entries(fields).forEach(([key, value]) => body.set(key, value))
-  body.set('media', file)
   return { formData: async () => body } as unknown as NextRequest
 }
 
@@ -49,6 +42,17 @@ describe('POST /api/community', () => {
 
     expect(response.status).toBe(500)
     expect(remove).toHaveBeenCalledOnce()
+    await expect(response.json()).resolves.toEqual({ error: '投稿を送信できません' })
+  })
+
+  it('removes uploaded media when the RPC transport rejects', async () => {
+    const { client, remove, upload } = makeClient()
+    client.rpc.mockRejectedValue(new Error('transport failure'))
+    const response = await POST(request({ kind: 'post', sender: '花子', content: '本文' }, new File(['image'], 'cake.png', { type: 'image/png' })))
+    const [[uploadedPath]] = upload.mock.calls
+
+    expect(response.status).toBe(500)
+    expect(remove).toHaveBeenCalledWith([uploadedPath])
     await expect(response.json()).resolves.toEqual({ error: '投稿を送信できません' })
   })
 
@@ -80,16 +84,13 @@ describe('POST /api/community', () => {
     expect(server.createServiceClient).not.toHaveBeenCalled()
   })
 
-  it('rejects invalid filenames before uploading media', async () => {
+  it('rejects overlong filenames before uploading media', async () => {
     const { upload } = makeClient()
-    const blankName = new File(['image'], '   ', { type: 'image/png' })
     const longName = new File(['image'], `${'a'.repeat(252)}.png`, { type: 'image/png' })
 
-    const blankNameResponse = await POST(requestWithFormData({ kind: 'message', sender: '花子', content: '本文' }, blankName))
-    const longNameResponse = await POST(requestWithFormData({ kind: 'message', sender: '花子', content: '本文' }, longName))
+    const response = await POST(request({ kind: 'message', sender: '花子', content: '本文' }, longName))
 
-    expect(blankNameResponse.status).toBe(400)
-    expect(longNameResponse.status).toBe(400)
+    expect(response.status).toBe(400)
     expect(upload).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/api/community-route.test.ts
+++ b/__tests__/api/community-route.test.ts
@@ -45,14 +45,13 @@ describe('POST /api/community', () => {
     await expect(response.json()).resolves.toEqual({ error: '投稿を送信できません' })
   })
 
-  it('removes uploaded media when the RPC transport rejects', async () => {
-    const { client, remove, upload } = makeClient()
+  it('does not remove uploaded media when the RPC transport rejects', async () => {
+    const { client, remove } = makeClient()
     client.rpc.mockRejectedValue(new Error('transport failure'))
     const response = await POST(request({ kind: 'post', sender: '花子', content: '本文' }, new File(['image'], 'cake.png', { type: 'image/png' })))
-    const [[uploadedPath]] = upload.mock.calls
 
     expect(response.status).toBe(500)
-    expect(remove).toHaveBeenCalledWith([uploadedPath])
+    expect(remove).not.toHaveBeenCalled()
     await expect(response.json()).resolves.toEqual({ error: '投稿を送信できません' })
   })
 

--- a/__tests__/app/api/media-route.test.ts
+++ b/__tests__/app/api/media-route.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const query = {
+  eq: vi.fn().mockReturnThis(),
+  or: vi.fn().mockReturnThis(),
+  limit: vi.fn().mockReturnThis(),
+  range: vi.fn().mockReturnThis(),
+  then: (resolve: (value: { data: never[]; error: null; count: number }) => unknown) =>
+    Promise.resolve(resolve({ data: [], error: null, count: 0 })),
+}
+
+vi.mock('@/lib/supabase/client', () => ({
+  getSupabase: () => ({
+    from: () => ({
+      select: () => ({
+        order: () => query,
+      }),
+    }),
+  }),
+}))
+
+import { GET } from '@/app/api/media/route'
+
+describe('GET /api/media', () => {
+  it('ignores invalid pagination and escapes PostgREST search syntax', async () => {
+    query.or.mockClear()
+    query.limit.mockClear()
+    query.range.mockClear()
+
+    const request = new NextRequest('http://localhost/api/media?search=a,b%22%5C&limit=Infinity&offset=-1')
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    expect(query.limit).not.toHaveBeenCalled()
+    expect(query.range).not.toHaveBeenCalled()
+    expect(query.or).toHaveBeenCalledWith(expect.stringContaining('a,b\\"\\\\'))
+  })
+})

--- a/__tests__/components/ContributorPromptButtons.test.tsx
+++ b/__tests__/components/ContributorPromptButtons.test.tsx
@@ -90,4 +90,25 @@ describe('Contributor prompts', () => {
     await waitFor(() => expect(uploadCommunityMedia).toHaveBeenCalledWith({ file, sender: '花子' }))
     expect(onSubmit).toHaveBeenCalledWith('花子', 'おめでとう！', undefined, 'images/post.png')
   })
+
+  it('rejects unsupported post media before upload', () => {
+    render(<PostForm onSubmit={vi.fn()} />)
+    const file = new File(['audio'], 'post.mp3', { type: 'audio/mpeg' })
+
+    fireEvent.change(document.querySelector('input[type="file"]') as HTMLInputElement, { target: { files: [file] } })
+
+    expect(screen.getByText('fileTypeError')).toBeInTheDocument()
+    expect(uploadCommunityMedia).not.toHaveBeenCalled()
+  })
+
+  it('rejects post media larger than the canonical 50MB limit', () => {
+    render(<PostForm onSubmit={vi.fn()} />)
+    const file = new File(['image'], 'post.png', { type: 'image/png' })
+    Object.defineProperty(file, 'size', { value: 50 * 1024 * 1024 + 1 })
+
+    fireEvent.change(document.querySelector('input[type="file"]') as HTMLInputElement, { target: { files: [file] } })
+
+    expect(screen.getByText('fileTooLargeWithLimit')).toBeInTheDocument()
+    expect(uploadCommunityMedia).not.toHaveBeenCalled()
+  })
 })

--- a/__tests__/components/ContributorPromptButtons.test.tsx
+++ b/__tests__/components/ContributorPromptButtons.test.tsx
@@ -1,9 +1,10 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { MessageForm } from '@/components/community/MessageForm'
 import PostForm from '@/components/community/PostForm'
 
 const sendMessage = vi.fn()
+const uploadCommunityMedia = vi.hoisted(() => vi.fn())
 
 vi.mock('@/lib/i18n/LanguageContext', () => ({
   useLanguage: () => ({
@@ -24,7 +25,7 @@ vi.mock('@/components/ui/Icon', () => ({
 }))
 
 vi.mock('@/lib/supabase/communityMedia', () => ({
-  uploadCommunityMedia: vi.fn(),
+  uploadCommunityMedia,
 }))
 
 vi.mock('@/lib/supabase/client', () => ({
@@ -33,6 +34,7 @@ vi.mock('@/lib/supabase/client', () => ({
 
 beforeEach(() => {
   sendMessage.mockReset()
+  uploadCommunityMedia.mockReset()
   localStorage.clear()
 })
 
@@ -72,5 +74,20 @@ describe('Contributor prompts', () => {
     fireEvent.click(prompt)
     expect(textarea).toHaveValue('既存の投稿')
     expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('uploads post media through the canonical community media helper', async () => {
+    uploadCommunityMedia.mockResolvedValue({ object_path: 'images/post.png' })
+    const onSubmit = vi.fn().mockResolvedValue(true)
+    render(<PostForm onSubmit={onSubmit} />)
+
+    fireEvent.change(screen.getByPlaceholderText('yourName'), { target: { value: '花子' } })
+    fireEvent.change(screen.getByPlaceholderText('typeMessage'), { target: { value: 'おめでとう！' } })
+    const file = new File(['image'], 'post.png', { type: 'image/png' })
+    fireEvent.change(document.querySelector('input[type="file"]') as HTMLInputElement, { target: { files: [file] } })
+    fireEvent.click(screen.getByRole('button', { name: 'postMessage' }))
+
+    await waitFor(() => expect(uploadCommunityMedia).toHaveBeenCalledWith({ file, sender: '花子' }))
+    expect(onSubmit).toHaveBeenCalledWith('花子', 'おめでとう！', undefined, 'images/post.png')
   })
 })

--- a/__tests__/components/ContributorPromptButtons.test.tsx
+++ b/__tests__/components/ContributorPromptButtons.test.tsx
@@ -91,6 +91,22 @@ describe('Contributor prompts', () => {
     expect(onSubmit).toHaveBeenCalledWith('花子', 'おめでとう！', undefined, 'images/post.png')
   })
 
+  it('accepts codec-qualified camera video MIME after normalization', async () => {
+    uploadCommunityMedia.mockResolvedValue({ object_path: 'videos/post.webm' })
+    const onSubmit = vi.fn().mockResolvedValue(true)
+    render(<PostForm onSubmit={onSubmit} />)
+
+    fireEvent.change(screen.getByPlaceholderText('yourName'), { target: { value: '花子' } })
+    fireEvent.change(screen.getByPlaceholderText('typeMessage'), { target: { value: '動画です' } })
+    const file = new File(['video'], 'post.webm', { type: 'video/webm;codecs=vp9' })
+    fireEvent.change(document.querySelector('input[type="file"]') as HTMLInputElement, { target: { files: [file] } })
+    fireEvent.click(screen.getByRole('button', { name: 'postMessage' }))
+
+    await waitFor(() => expect(uploadCommunityMedia).toHaveBeenCalled())
+    expect(uploadCommunityMedia.mock.calls[0][0].file.type).toBe('video/webm')
+    expect(onSubmit).toHaveBeenCalledWith('花子', '動画です', undefined, 'videos/post.webm')
+  })
+
   it('rejects unsupported post media before upload', () => {
     render(<PostForm onSubmit={vi.fn()} />)
     const file = new File(['audio'], 'post.mp3', { type: 'audio/mpeg' })

--- a/__tests__/components/MessageForm.test.tsx
+++ b/__tests__/components/MessageForm.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MessageForm } from '@/components/community/MessageForm'
+
+const sendMessage = vi.hoisted(() => vi.fn())
+const uploadCommunityMedia = vi.hoisted(() => vi.fn())
+const fetchMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/i18n/LanguageContext', () => ({
+  useLanguage: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('@/lib/hooks/useMessages', () => ({
+  useMessages: () => ({ sendMessage }),
+}))
+
+vi.mock('@/components/community/CameraCapture', () => ({
+  CameraCapture: () => null,
+}))
+
+vi.mock('@/components/ui/Icon', () => ({
+  Icon: () => null,
+}))
+
+vi.mock('@/lib/supabase/communityMedia', () => ({
+  uploadCommunityMedia,
+}))
+
+beforeEach(() => {
+  sendMessage.mockReset()
+  uploadCommunityMedia.mockReset()
+  fetchMock.mockReset()
+  vi.stubGlobal('fetch', fetchMock)
+  localStorage.clear()
+})
+
+describe('MessageForm', () => {
+  it('submits media through /api/community with FormData without using the browser upload helper', async () => {
+    fetchMock.mockResolvedValue({ ok: true })
+    render(<MessageForm birthdayPerson="太郎" />)
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'yourName' }), { target: { value: '花子' } })
+    fireEvent.change(screen.getByRole('textbox', { name: 'messagePlaceholder' }), { target: { value: 'おめでとう！' } })
+    const file = new File(['image'], 'message.png', { type: 'image/png' })
+    fireEvent.change(document.querySelector('input[type="file"]') as HTMLInputElement, { target: { files: [file] } })
+    fireEvent.click(screen.getByRole('button', { name: 'sendWish' }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/community', expect.objectContaining({ method: 'POST' })))
+    const [, request] = fetchMock.mock.calls[0]
+    const body = request.body as FormData
+    expect(body.get('kind')).toBe('message')
+    expect(body.get('sender')).toBe('花子')
+    expect(body.get('content')).toBe('おめでとう！')
+    expect(body.get('birthdayPerson')).toBe('太郎')
+    expect(body.get('media')).toBeInstanceOf(File)
+    expect((body.get('media') as File).name).toBe('message.png')
+    expect(uploadCommunityMedia).not.toHaveBeenCalled()
+    expect(sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('keeps the text-only path on sendMessage', async () => {
+    sendMessage.mockResolvedValue(true)
+    render(<MessageForm />)
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'yourName' }), { target: { value: '花子' } })
+    fireEvent.change(screen.getByRole('textbox', { name: 'messagePlaceholder' }), { target: { value: 'おめでとう！' } })
+    fireEvent.click(screen.getByRole('button', { name: 'sendWish' }))
+
+    await waitFor(() => expect(sendMessage).toHaveBeenCalledWith('花子', 'おめでとう！', undefined, undefined))
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(uploadCommunityMedia).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/integration/community-submission-rpc-migration.test.ts
+++ b/__tests__/integration/community-submission-rpc-migration.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const migration = readFileSync(join(process.cwd(), 'supabase', 'migrations', '20260901000000_add_community_submission_rpc.sql'), 'utf8')
+
+describe('community submission RPC migration', () => {
+  it('keeps the transaction RPC fixed, constrained, and service-only', () => {
+    expect(migration).toContain('create or replace function public.create_community_submission(')
+    expect(migration).toContain('security definer')
+    expect(migration).toContain('set search_path = pg_catalog, public')
+    expect(migration).toContain("p_kind not in ('message', 'post')")
+    expect(migration).toContain("p_media_kind not in ('image', 'video', 'audio')")
+    expect(migration).toContain("p_media_kind = 'image' and (p_mime_type not like 'image/%' or p_object_path !~ '^images/')")
+    expect(migration).toContain("p_media_kind = 'video' and (p_mime_type not like 'video/%' or p_object_path !~ '^videos/')")
+    expect(migration).toContain("p_media_kind = 'audio' and (p_mime_type not like 'audio/%' or p_object_path !~ '^audios/')")
+    expect(migration).toContain("p_object_path !~ '^(images|videos|audios)/[0-9a-f-]+\\.[a-z0-9]+$'")
+    expect(migration).toContain('revoke execute on function public.create_community_submission')
+    expect(migration).toContain('from public, anon, authenticated;')
+    expect(migration).toContain('to service_role;')
+    expect(migration).not.toMatch(/grant .*delete .*community/i)
+  })
+
+  it('accepts the generated UUID object path contract', () => {
+    expect(/^images\/[0-9a-f-]+\.[a-z0-9]+$/.test('images/550e8400-e29b-41d4-a716-446655440000.png')).toBe(true)
+  })
+
+  it('rejects traversal, wrong prefixes, and MIME/category mismatches', () => {
+    const pathPattern = /^(images|videos|audios)\/[0-9a-f-]+\.[a-z0-9]+$/
+    expect(pathPattern.test('images/../private.png')).toBe(false)
+    expect(pathPattern.test('videos/550e8400-e29b-41d4-a716-446655440000.png')).toBe(true)
+    expect(pathPattern.test('image/550e8400-e29b-41d4-a716-446655440000.png')).toBe(false)
+    expect('image/png'.startsWith('video/')).toBe(false)
+    expect('video/mp4'.startsWith('image/')).toBe(false)
+  })
+})

--- a/__tests__/lib/community-media.test.ts
+++ b/__tests__/lib/community-media.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, it, vi } from 'vitest'
 
 const upload = vi.fn().mockResolvedValue({ error: null })
+const remove = vi.fn().mockResolvedValue({ error: null })
 const insert = vi.fn().mockReturnValue({
   select: vi.fn().mockReturnValue({ single: vi.fn().mockResolvedValue({ data: { id: 1 }, error: null }) }),
 })
 
 vi.mock('@/lib/supabase/client', () => ({
   getSupabase: () => ({
-    storage: { from: () => ({ upload, getPublicUrl: () => ({ data: { publicUrl: 'https://example.com/media' } }) }) },
+    storage: { from: () => ({ upload, remove, getPublicUrl: () => ({ data: { publicUrl: 'https://example.com/media' } }) }) },
     from: () => ({ insert }),
   }),
 }))
@@ -29,5 +30,16 @@ describe('uploadCommunityMedia', () => {
       media_kind: 'image',
       original_name: 'cake.png',
     }))
+  })
+
+  it('removes the object when metadata insert fails', async () => {
+    const insertError = new Error('insert failed')
+    insert.mockReturnValueOnce({
+      select: vi.fn().mockReturnValue({ single: vi.fn().mockResolvedValue({ data: null, error: insertError }) }),
+    })
+
+    await expect(uploadCommunityMedia({ file: new File(['image'], 'cake.png', { type: 'image/png' }), sender: '花子' }))
+      .rejects.toBe(insertError)
+    expect(remove).toHaveBeenCalledWith(expect.arrayContaining([expect.stringMatching(/^images\//)]))
   })
 })

--- a/app/api/community/route.ts
+++ b/app/api/community/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createCommunitySubmission, type CommunitySubmissionInput } from '@/lib/community/server'
+import { validateCommunityMediaFile } from '@/lib/validations/upload'
+
+const COMMUNITY_MEDIA_MIME_TYPES = new Set([
+  'image/jpeg', 'image/png', 'image/webp', 'image/gif',
+  'video/mp4', 'video/webm',
+  'audio/webm', 'audio/mpeg', 'audio/mp4', 'audio/wav', 'audio/ogg',
+])
+
+function normalizeMimeType(value: string): string {
+  return value.split(';', 1)[0].trim().toLowerCase()
+}
+
+function parseText(formData: FormData, key: string, maxLength: number): string | null {
+  const value = formData.get(key)
+  if (typeof value !== 'string') return null
+  const normalized = value.trim()
+  return normalized && normalized.length <= maxLength ? normalized : null
+}
+
+function parseInput(formData: FormData): CommunitySubmissionInput | null {
+  const kind = formData.get('kind')
+  if (kind !== 'message' && kind !== 'post') return null
+  const sender = parseText(formData, 'sender', 100)
+  const content = parseText(formData, 'content', 1000)
+  if (!sender || !content) return null
+
+  const birthdayPerson = parseText(formData, 'birthdayPerson', 100)
+  const description = parseText(formData, 'description', 1000)
+  const fileValue = formData.get('media')
+  if (fileValue !== null && (typeof fileValue !== 'object' || typeof (fileValue as Blob).size !== 'number' || typeof (fileValue as File).name !== 'string')) return null
+
+  let file = fileValue as File | null
+  if (file && file.size === 0 && !file.name) file = null
+  if (file) {
+    const mimeType = normalizeMimeType(file.type)
+    if (!COMMUNITY_MEDIA_MIME_TYPES.has(mimeType)) return null
+    file = new File([file], file.name, { type: mimeType, lastModified: file.lastModified })
+    if (!validateCommunityMediaFile(file).valid) return null
+  }
+
+  return { kind, sender, content, birthdayPerson, description, file }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const input = parseInput(await request.formData())
+    if (!input) return NextResponse.json({ error: '投稿内容が無効です' }, { status: 400 })
+
+    const data = await createCommunitySubmission(input)
+    return NextResponse.json({ data }, { status: 201 })
+  } catch {
+    return NextResponse.json({ error: '投稿を送信できません' }, { status: 500 })
+  }
+}

--- a/app/api/community/route.ts
+++ b/app/api/community/route.ts
@@ -19,6 +19,15 @@ function parseText(formData: FormData, key: string, maxLength: number): string |
   return normalized && normalized.length <= maxLength ? normalized : null
 }
 
+function parseOptionalText(formData: FormData, key: string, maxLength: number): string | null | undefined {
+  const value = formData.get(key)
+  if (value === null) return null
+  if (typeof value !== 'string') return undefined
+  const normalized = value.trim()
+  if (!normalized) return null
+  return normalized.length <= maxLength ? normalized : undefined
+}
+
 function parseInput(formData: FormData): CommunitySubmissionInput | null {
   const kind = formData.get('kind')
   if (kind !== 'message' && kind !== 'post') return null
@@ -26,14 +35,17 @@ function parseInput(formData: FormData): CommunitySubmissionInput | null {
   const content = parseText(formData, 'content', 1000)
   if (!sender || !content) return null
 
-  const birthdayPerson = parseText(formData, 'birthdayPerson', 100)
-  const description = parseText(formData, 'description', 1000)
+  const birthdayPerson = parseOptionalText(formData, 'birthdayPerson', 100)
+  const description = parseOptionalText(formData, 'description', 1000)
+  if (birthdayPerson === undefined || description === undefined) return null
   const fileValue = formData.get('media')
   if (fileValue !== null && (typeof fileValue !== 'object' || typeof (fileValue as Blob).size !== 'number' || typeof (fileValue as File).name !== 'string')) return null
 
   let file = fileValue as File | null
   if (file && file.size === 0 && !file.name) file = null
   if (file) {
+    const fileName = file.name.trim()
+    if (!fileName || fileName.length > 255) return null
     const mimeType = normalizeMimeType(file.type)
     if (!COMMUNITY_MEDIA_MIME_TYPES.has(mimeType)) return null
     file = new File([file], file.name, { type: mimeType, lastModified: file.lastModified })

--- a/app/api/media/route.ts
+++ b/app/api/media/route.ts
@@ -1,6 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getSupabase } from '@/lib/supabase/client'
 
+const MAX_MEDIA_LIMIT = 100
+const MAX_MEDIA_OFFSET = 1_000_000
+
+function parseBoundedInteger(value: string | null, min: number, max: number): number | undefined {
+  if (value === null || !/^\d+$/.test(value)) return undefined
+  const parsed = Number(value)
+  return Number.isSafeInteger(parsed) && parsed >= min && parsed <= max ? parsed : undefined
+}
+
+function escapePostgrestSearch(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+}
+
 export async function GET(request: NextRequest) {
   try {
     const supabase = getSupabase()
@@ -25,15 +38,19 @@ export async function GET(request: NextRequest) {
     }
 
     if (search) {
-      query = query.or(`original_name.ilike.%${search}%,description.ilike.%${search}%`)
+      const escapedSearch = escapePostgrestSearch(search)
+      query = query.or(`original_name.ilike."%${escapedSearch}%",description.ilike."%${escapedSearch}%"`)
     }
 
-    if (limit) {
-      query = query.limit(parseInt(limit))
+    const validLimit = parseBoundedInteger(limit, 1, MAX_MEDIA_LIMIT)
+    const validOffset = parseBoundedInteger(offset, 0, MAX_MEDIA_OFFSET)
+
+    if (validLimit !== undefined) {
+      query = query.limit(validLimit)
     }
 
-    if (offset) {
-      query = query.range(parseInt(offset), parseInt(offset) + parseInt(limit || '20') - 1)
+    if (validOffset !== undefined) {
+      query = query.range(validOffset, validOffset + (validLimit ?? 20) - 1)
     }
 
     const { data, error, count } = await query

--- a/components/community/MessageForm.tsx
+++ b/components/community/MessageForm.tsx
@@ -7,6 +7,7 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { CameraCapture } from './CameraCapture'
 import { ContributorPromptButtons } from './ContributorPromptButtons'
 import { uploadCommunityMedia } from '@/lib/supabase/communityMedia'
+import { getMediaKind, validateCommunityMediaFile } from '@/lib/validations/upload'
 import { Icon } from '@/components/ui/Icon'
 
 interface MessageFormProps {
@@ -38,31 +39,32 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
   const [cameraMode, setCameraMode] = useState<'photo' | 'video'>('photo')
   const fileInputRef = useRef<HTMLInputElement>(null)
 
+  const normalizeMediaFile = (file: File): File => {
+    const baseMimeType = file.type.split(';', 1)[0].trim().toLowerCase()
+    if (baseMimeType === file.type) return file
+    return new File([file], file.name, { type: baseMimeType, lastModified: file.lastModified })
+  }
+
+  const handleSelectedFile = (file: File): boolean => {
+    const normalizedFile = normalizeMediaFile(file)
+    const validation = validateCommunityMediaFile(normalizedFile)
+    if (!validation.valid || getMediaKind(normalizedFile.type) === 'audio') {
+      setError(!validation.valid && file.size > 50 * 1024 * 1024
+        ? t('fileTooLargeWithLimit', { size: 50 })
+        : t('fileTypeError'))
+      return false
+    }
+
+    setSelectedFile(normalizedFile)
+    setError(null)
+    if (previewUrl) URL.revokeObjectURL(previewUrl)
+    setPreviewUrl(URL.createObjectURL(normalizedFile))
+    return true
+  }
+
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
-    if (!file) return
-
-    const isImage = file.type.startsWith('image/')
-    const isVideo = file.type.startsWith('video/')
-    
-    if (!isImage && !isVideo) {
-      setError(t('fileTypeError'))
-      return
-    }
-
-    // ファイルサイズを検証（画像は50MB、動画は100MBまで）
-    const maxSize = isVideo ? 100 * 1024 * 1024 : 50 * 1024 * 1024
-    if (file.size > maxSize) {
-      setError(t('fileTooLargeWithLimit', { size: isVideo ? 100 : 50 }))
-      return
-    }
-
-    setSelectedFile(file)
-    setError(null)
-
-    if (previewUrl) URL.revokeObjectURL(previewUrl)
-    const url = URL.createObjectURL(file)
-    setPreviewUrl(url)
+    if (file) handleSelectedFile(file)
   }
 
   const removeFile = () => {
@@ -81,7 +83,7 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
 
     try {
       const media = await uploadCommunityMedia({
-        file,
+        file: normalizeMediaFile(file),
         sender: sender.trim(),
         birthdayPerson,
       })
@@ -427,11 +429,7 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
         <CameraCapture
           mode={cameraMode}
           onCapture={(file) => {
-            setSelectedFile(file)
-            if (previewUrl) URL.revokeObjectURL(previewUrl)
-            const url = URL.createObjectURL(file)
-            setPreviewUrl(url)
-            setShowCamera(false)
+            if (handleSelectedFile(file)) setShowCamera(false)
           }}
           onClose={() => setShowCamera(false)}
         />

--- a/components/community/MessageForm.tsx
+++ b/components/community/MessageForm.tsx
@@ -6,7 +6,6 @@ import { useMessages } from '@/lib/hooks/useMessages'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { CameraCapture } from './CameraCapture'
 import { ContributorPromptButtons } from './ContributorPromptButtons'
-import { uploadCommunityMedia } from '@/lib/supabase/communityMedia'
 import { getMediaKind, validateCommunityMediaFile } from '@/lib/validations/upload'
 import { Icon } from '@/components/ui/Icon'
 
@@ -78,20 +77,30 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
     }
   }
 
-  const uploadFile = async (file: File): Promise<string | null> => {
-    setUploadProgress(10)
-
-    try {
-      const media = await uploadCommunityMedia({
-        file: normalizeMediaFile(file),
-        sender: sender.trim(),
-        birthdayPerson,
-      })
-      setUploadProgress(100)
-      return media.object_path
-    } catch {
-      return null
+  const submitMessage = async (
+    payload: { sender: string; message: string; birthdayPerson?: string; mediaObjectPath?: string }
+  ): Promise<boolean> => {
+    if (selectedFile) {
+      const formData = new FormData()
+      formData.set('kind', 'message')
+      formData.set('sender', payload.sender)
+      formData.set('content', payload.message)
+      if (payload.birthdayPerson) formData.set('birthdayPerson', payload.birthdayPerson)
+      formData.set('media', selectedFile, selectedFile.name)
+      try {
+        const response = await fetch('/api/community', { method: 'POST', body: formData })
+        if (!response.ok) {
+          const errorBody = await response.json().catch(() => null) as { error?: string } | null
+          setError(errorBody?.error ?? t('sendMessageFailed'))
+          return false
+        }
+        return true
+      } catch {
+        setError(t('genericError'))
+        return false
+      }
     }
+    return sendMessage(payload.sender, payload.message, payload.birthdayPerson, payload.mediaObjectPath)
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -106,24 +115,13 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
     setUploadProgress(0)
 
     try {
-      let mediaObjectPath: string | null = null
-
-      if (selectedFile) {
-        mediaObjectPath = await uploadFile(selectedFile)
-        if (!mediaObjectPath) {
-          setError(t('uploadFileFailed'))
-          setIsSubmitting(false)
-          return
-        }
-      }
-
-      // メディアURL付きでメッセージを送信
-      const success = await sendMessage(
-        sender.trim(), 
-        message.trim(), 
+      // メディア付き投稿は server-side の transaction 経路 /api/community に統一し、
+      // メディアアップロードと message 挿入の不整合による孤立 object を防ぐ。
+      const success = await submitMessage({
+        sender: sender.trim(),
+        message: message.trim(),
         birthdayPerson,
-        mediaObjectPath || undefined
-      )
+      })
 
       if (success) {
         // 名前を共有ストレージに保存する（他のフォームと共用）
@@ -132,8 +130,6 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
         setMessage('')
         removeFile()
         onSuccess?.()
-      } else {
-        setError(t('sendMessageFailed'))
       }
     } catch {
       setError(t('genericError'))

--- a/components/community/PostForm.tsx
+++ b/components/community/PostForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect } from 'react'
 import { uploadCommunityMedia } from '@/lib/supabase/communityMedia'
+import { getMediaKind, validateCommunityMediaFile } from '@/lib/validations/upload'
 import { CameraCapture } from './CameraCapture'
 import { ContributorPromptButtons } from './ContributorPromptButtons'
 import { Icon } from '@/components/ui/Icon'
@@ -38,17 +39,11 @@ export default function PostForm({ onSubmit }: PostFormProps) {
     const file = e.target.files?.[0]
     if (!file) return
 
-    const isImage = file.type.startsWith('image/')
-    const isVideo = file.type.startsWith('video/')
-    
-    if (!isImage && !isVideo) {
-      setError(t('fileTypeError'))
-      return
-    }
-
-    const maxSize = isVideo ? 100 * 1024 * 1024 : 50 * 1024 * 1024
-    if (file.size > maxSize) {
-      setError(t('fileTooLargeWithLimit', { size: isVideo ? 100 : 50 }))
+    const validation = validateCommunityMediaFile(file)
+    if (!validation.valid || getMediaKind(file.type) === 'audio') {
+      setError(!validation.valid && file.size > 50 * 1024 * 1024
+        ? t('fileTooLargeWithLimit', { size: 50 })
+        : t('fileTypeError'))
       return
     }
 

--- a/components/community/PostForm.tsx
+++ b/components/community/PostForm.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useRef, useEffect } from 'react'
-import { getSupabase } from '@/lib/supabase/client'
+import { uploadCommunityMedia } from '@/lib/supabase/communityMedia'
 import { CameraCapture } from './CameraCapture'
 import { ContributorPromptButtons } from './ContributorPromptButtons'
 import { Icon } from '@/components/ui/Icon'
@@ -69,20 +69,10 @@ export default function PostForm({ onSubmit }: PostFormProps) {
 
   const uploadFile = async (file: File): Promise<string | null> => {
     try {
-      const supabase = getSupabase()
-      const isVideo = file.type.startsWith('video/')
-      const bucket = isVideo ? 'video' : 'media'
-      const ext = file.name.split('.').pop()
-      const fileName = `${isVideo ? 'video' : 'image'}_${Date.now()}.${ext}`
-
       setUploadProgress(10)
-      const { error: uploadError } = await supabase.storage.from(bucket).upload(fileName, file)
-      if (uploadError) throw uploadError
-
-      setUploadProgress(80)
-      const { data: urlData } = supabase.storage.from(bucket).getPublicUrl(fileName)
+      const data = await uploadCommunityMedia({ file, sender: author })
       setUploadProgress(100)
-      return urlData.publicUrl
+      return data.object_path
     } catch (err) {
       console.error('Upload error:', err)
       return null

--- a/components/community/PostForm.tsx
+++ b/components/community/PostForm.tsx
@@ -35,22 +35,25 @@ export default function PostForm({ onSubmit }: PostFormProps) {
   const [cameraMode, setCameraMode] = useState<'photo' | 'video'>('photo')
   const fileInputRef = useRef<HTMLInputElement>(null)
 
-  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0]
-    if (!file) return
-
+  const handleSelectedFile = (file: File): boolean => {
     const validation = validateCommunityMediaFile(file)
     if (!validation.valid || getMediaKind(file.type) === 'audio') {
       setError(!validation.valid && file.size > 50 * 1024 * 1024
         ? t('fileTooLargeWithLimit', { size: 50 })
         : t('fileTypeError'))
-      return
+      return false
     }
 
     setSelectedFile(file)
     setError(null)
     if (previewUrl) URL.revokeObjectURL(previewUrl)
     setPreviewUrl(URL.createObjectURL(file))
+    return true
+  }
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) handleSelectedFile(file)
   }
 
   const removeFile = () => {
@@ -185,7 +188,7 @@ export default function PostForm({ onSubmit }: PostFormProps) {
           <ContributorPromptButtons hasContent={content.trim().length > 0} onSelect={setContent} />
 
           {/* メディアアップロード */}
-          <input ref={fileInputRef} type="file" accept="image/*,video/*" onChange={handleFileSelect} style={{ display: 'none' }} />
+          <input ref={fileInputRef} type="file" accept="image/jpeg,image/png,image/webp,image/gif,video/mp4,video/webm" onChange={handleFileSelect} style={{ display: 'none' }} />
           
           {!selectedFile ? (
             <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
@@ -255,9 +258,7 @@ export default function PostForm({ onSubmit }: PostFormProps) {
         <CameraCapture
           mode={cameraMode}
           onCapture={(file) => {
-            setSelectedFile(file)
-            if (previewUrl) URL.revokeObjectURL(previewUrl)
-            setPreviewUrl(URL.createObjectURL(file))
+            handleSelectedFile(file)
             setShowCamera(false)
           }}
           onClose={() => setShowCamera(false)}

--- a/components/community/PostForm.tsx
+++ b/components/community/PostForm.tsx
@@ -35,19 +35,26 @@ export default function PostForm({ onSubmit }: PostFormProps) {
   const [cameraMode, setCameraMode] = useState<'photo' | 'video'>('photo')
   const fileInputRef = useRef<HTMLInputElement>(null)
 
+  const normalizeMediaFile = (file: File): File => {
+    const baseMimeType = file.type.split(';', 1)[0].trim().toLowerCase()
+    if (baseMimeType === file.type) return file
+    return new File([file], file.name, { type: baseMimeType, lastModified: file.lastModified })
+  }
+
   const handleSelectedFile = (file: File): boolean => {
-    const validation = validateCommunityMediaFile(file)
-    if (!validation.valid || getMediaKind(file.type) === 'audio') {
+    const normalizedFile = normalizeMediaFile(file)
+    const validation = validateCommunityMediaFile(normalizedFile)
+    if (!validation.valid || getMediaKind(normalizedFile.type) === 'audio') {
       setError(!validation.valid && file.size > 50 * 1024 * 1024
         ? t('fileTooLargeWithLimit', { size: 50 })
         : t('fileTypeError'))
       return false
     }
 
-    setSelectedFile(file)
+    setSelectedFile(normalizedFile)
     setError(null)
     if (previewUrl) URL.revokeObjectURL(previewUrl)
-    setPreviewUrl(URL.createObjectURL(file))
+    setPreviewUrl(URL.createObjectURL(normalizedFile))
     return true
   }
 
@@ -68,7 +75,7 @@ export default function PostForm({ onSubmit }: PostFormProps) {
   const uploadFile = async (file: File): Promise<string | null> => {
     try {
       setUploadProgress(10)
-      const data = await uploadCommunityMedia({ file, sender: author })
+      const data = await uploadCommunityMedia({ file: normalizeMediaFile(file), sender: author })
       setUploadProgress(100)
       return data.object_path
     } catch (err) {

--- a/docs/community-rate-limit-production-proposal.md
+++ b/docs/community-rate-limit-production-proposal.md
@@ -1,0 +1,38 @@
+# 匿名コミュニティ投稿の本番レート制限案
+
+## 結論
+
+`/api/community` は未認証で `service_role` を使うため、本番ではアプリケーションのインスタンス内メモリだけに依存する rate limit を採用しません。現在の repository には共有状態を持つ rate-limit backend や provider integration がないため、この文書は production configuration の代わりではなく、適用前の proposal です。
+
+## 対象と境界
+
+- 対象 endpoint は `POST /api/community` です。
+- `sender`、`content`、`birthdayPerson`、`description` の既存 length validation と、media MIME・size validation は維持します。
+- upload された object と submission row の作成を rate limit の対象にします。
+- read-only の `GET /api/media` はこの write quota と分離します。
+
+## 推奨する本番設定
+
+共有状態を持つ edge/platform rate limiter を endpoint の前段に置き、次の値を初期値として承認します。
+
+- 1 client fingerprint あたり 10 requests / 10 minutes
+- 1 client fingerprint あたり 50 requests / 24 hours
+- request body 上限は既存の 50 MiB media limit 以下で、platform request limit も同じかそれより厳しくします
+- quota 超過時は HTTP `429`、安全な error envelope、`Retry-After` を返します
+- `service_role`、request body、media content、raw IP を log に出しません
+- client fingerprint は provider/platform が提供する ephemeral key を優先し、長期的な device fingerprint は作成しません
+
+同一 client の共有 NAT を理由に global anonymous quota を置く場合は、正当な利用者を巻き込むため、値を実 traffic で再評価します。allowlist や bypass は追加しません。
+
+## 実装前の確認
+
+1. 採用する platform/provider と共有 counter の retention を確定します。
+2. limit key が cross-instance で共有されることを確認します。
+3. `429` response、`Retry-After`、provider failure の挙動を staging で確認します。
+4. Storage upload と RPC failure の compensating cleanup が quota rejection の前に発生しないことを確認します。
+5. production dashboard で accepted, rejected, upload failure, RPC failure を分けて監視します。
+6. 期限、通報、moderation、retention policy と値を運用担当が承認します。
+
+## 未実施
+
+この repository には provider credentials、production platform configuration、shared rate-limit store がないため、本番 rate limit はまだ設定されていません。migration、secret、deployment、provider account の変更はこの proposal では行いません。

--- a/docs/community-rate-limit-production-proposal.md
+++ b/docs/community-rate-limit-production-proposal.md
@@ -17,7 +17,7 @@
 
 - 1 client fingerprint あたり 10 requests / 10 minutes
 - 1 client fingerprint あたり 50 requests / 24 hours
-- request body 上限は既存の 50 MiB media limit 以下で、platform request limit も同じかそれより厳しくします
+- request body の media 上限は既存の 50 MiB とし、multipart overhead を含む platform request limit は 50 MiB を超える値に設定します
 - quota 超過時は HTTP `429`、安全な error envelope、`Retry-After` を返します
 - `service_role`、request body、media content、raw IP を log に出しません
 - client fingerprint は provider/platform が提供する ephemeral key を優先し、長期的な device fingerprint は作成しません

--- a/lib/community/server.ts
+++ b/lib/community/server.ts
@@ -31,30 +31,34 @@ export async function createCommunitySubmission(input: CommunitySubmissionInput)
     if (error) throw error
   }
 
-  const { data, error } = await serviceClient.rpc('create_community_submission', {
-    p_kind: input.kind,
-    p_sender: input.sender,
-    p_content: input.content,
-    p_birthday_person: input.birthdayPerson,
-    p_description: input.description,
-    p_object_path: objectPath,
-    p_media_kind: mediaKind,
-    p_mime_type: file?.type ?? null,
-    p_original_name: file?.name ?? null,
-    p_size_bytes: file?.size ?? null,
-  })
-
-  if (error) {
-    if (objectPath) {
-      try {
-        const { error: cleanupError } = await serviceClient.storage.from(COMMUNITY_MEDIA_BUCKET).remove([objectPath])
-        if (cleanupError) console.error('Community media cleanup failed')
-      } catch {
-        console.error('Community media cleanup failed')
-      }
+  const cleanupUploadedMedia = async () => {
+    if (!objectPath) return
+    try {
+      const { error: cleanupError } = await serviceClient.storage.from(COMMUNITY_MEDIA_BUCKET).remove([objectPath])
+      if (cleanupError) console.error('Community media cleanup failed')
+    } catch {
+      console.error('Community media cleanup failed')
     }
-    throw error
   }
 
-  return data
+  try {
+    const { data, error } = await serviceClient.rpc('create_community_submission', {
+      p_kind: input.kind,
+      p_sender: input.sender,
+      p_content: input.content,
+      p_birthday_person: input.birthdayPerson,
+      p_description: input.description,
+      p_object_path: objectPath,
+      p_media_kind: mediaKind,
+      p_mime_type: file?.type ?? null,
+      p_original_name: file?.name ?? null,
+      p_size_bytes: file?.size ?? null,
+    })
+
+    if (error) throw error
+    return data
+  } catch (error) {
+    await cleanupUploadedMedia()
+    throw error
+  }
 }

--- a/lib/community/server.ts
+++ b/lib/community/server.ts
@@ -1,0 +1,60 @@
+import { createServiceClient } from '@/lib/time-capsule/server'
+import { getMediaKind, type CommunityMediaKind } from '@/lib/validations/upload'
+
+const COMMUNITY_MEDIA_BUCKET = 'community-media'
+
+export type CommunitySubmissionKind = 'message' | 'post'
+
+export type CommunitySubmissionInput = {
+  kind: CommunitySubmissionKind
+  sender: string
+  content: string
+  birthdayPerson: string | null
+  description: string | null
+  file: File | null
+}
+
+export async function createCommunitySubmission(input: CommunitySubmissionInput): Promise<unknown> {
+  const serviceClient = createServiceClient()
+  let objectPath: string | null = null
+  let mediaKind: CommunityMediaKind | null = null
+  const file = input.file
+
+  if (file) {
+    mediaKind = getMediaKind(file.type)
+    if (!mediaKind) throw new Error('サポートされていないファイル形式です')
+    const extension = file.name.trim().split('.').pop()?.toLowerCase().replace(/[^a-z0-9]/g, '') || 'bin'
+    objectPath = `${mediaKind}s/${crypto.randomUUID()}.${extension}`
+    const { error } = await serviceClient.storage
+      .from(COMMUNITY_MEDIA_BUCKET)
+      .upload(objectPath, file, { contentType: file.type, upsert: false })
+    if (error) throw error
+  }
+
+  const { data, error } = await serviceClient.rpc('create_community_submission', {
+    p_kind: input.kind,
+    p_sender: input.sender,
+    p_content: input.content,
+    p_birthday_person: input.birthdayPerson,
+    p_description: input.description,
+    p_object_path: objectPath,
+    p_media_kind: mediaKind,
+    p_mime_type: file?.type ?? null,
+    p_original_name: file?.name ?? null,
+    p_size_bytes: file?.size ?? null,
+  })
+
+  if (error) {
+    if (objectPath) {
+      try {
+        const { error: cleanupError } = await serviceClient.storage.from(COMMUNITY_MEDIA_BUCKET).remove([objectPath])
+        if (cleanupError) console.error('Community media cleanup failed')
+      } catch {
+        console.error('Community media cleanup failed')
+      }
+    }
+    throw error
+  }
+
+  return data
+}

--- a/lib/community/server.ts
+++ b/lib/community/server.ts
@@ -41,24 +41,23 @@ export async function createCommunitySubmission(input: CommunitySubmissionInput)
     }
   }
 
-  try {
-    const { data, error } = await serviceClient.rpc('create_community_submission', {
-      p_kind: input.kind,
-      p_sender: input.sender,
-      p_content: input.content,
-      p_birthday_person: input.birthdayPerson,
-      p_description: input.description,
-      p_object_path: objectPath,
-      p_media_kind: mediaKind,
-      p_mime_type: file?.type ?? null,
-      p_original_name: file?.name ?? null,
-      p_size_bytes: file?.size ?? null,
-    })
+  const { data, error } = await serviceClient.rpc('create_community_submission', {
+    p_kind: input.kind,
+    p_sender: input.sender,
+    p_content: input.content,
+    p_birthday_person: input.birthdayPerson,
+    p_description: input.description,
+    p_object_path: objectPath,
+    p_media_kind: mediaKind,
+    p_mime_type: file?.type ?? null,
+    p_original_name: file?.name ?? null,
+    p_size_bytes: file?.size ?? null,
+  })
 
-    if (error) throw error
-    return data
-  } catch (error) {
+  if (error) {
     await cleanupUploadedMedia()
     throw error
   }
+
+  return data
 }

--- a/lib/supabase/communityMedia.ts
+++ b/lib/supabase/communityMedia.ts
@@ -26,7 +26,22 @@ export async function uploadCommunityMedia({
     throw new Error('送信者名が無効です')
   }
 
-  const extension = file.name.split('.').pop()?.toLowerCase().replace(/[^a-z0-9]/g, '') || 'bin'
+  const normalizedBirthdayPerson = birthdayPerson?.trim() || null
+  if (normalizedBirthdayPerson && normalizedBirthdayPerson.length > 100) {
+    throw new Error('誕生日の人の名前が無効です')
+  }
+
+  const normalizedDescription = description?.trim() || null
+  if (normalizedDescription && normalizedDescription.length > 1000) {
+    throw new Error('説明が長すぎます')
+  }
+
+  const normalizedOriginalName = file.name.trim()
+  if (!normalizedOriginalName || normalizedOriginalName.length > 255) {
+    throw new Error('ファイル名が無効です')
+  }
+
+  const extension = normalizedOriginalName.split('.').pop()?.toLowerCase().replace(/[^a-z0-9]/g, '') || 'bin'
   const objectPath = `${mediaKind}s/${crypto.randomUUID()}.${extension}`
   const supabase = getSupabase()
   const { error: uploadError } = await supabase.storage
@@ -42,15 +57,23 @@ export async function uploadCommunityMedia({
       object_path: objectPath,
       media_kind: mediaKind,
       mime_type: file.type,
-      original_name: file.name,
+      original_name: normalizedOriginalName,
       size_bytes: file.size,
-      birthday_person: birthdayPerson?.trim() || null,
-      description: description?.trim() || null,
+      birthday_person: normalizedBirthdayPerson,
+      description: normalizedDescription,
     })
     .select()
     .single()
 
-  if (insertError) throw insertError
+  if (insertError) {
+    try {
+      const { error: cleanupError } = await supabase.storage.from('community-media').remove([objectPath])
+      if (cleanupError) console.error('Failed to clean up uploaded community media:', cleanupError)
+    } catch (cleanupError) {
+      console.error('Failed to clean up uploaded community media:', cleanupError)
+    }
+    throw insertError
+  }
 
   const { data: urlData } = supabase.storage.from('community-media').getPublicUrl(objectPath)
   return { ...data, media_url: urlData.publicUrl }

--- a/supabase/migrations/20260901000000_add_community_submission_rpc.sql
+++ b/supabase/migrations/20260901000000_add_community_submission_rpc.sql
@@ -1,0 +1,87 @@
+begin;
+
+create or replace function public.create_community_submission(
+  p_kind text,
+  p_sender text,
+  p_content text,
+  p_birthday_person text default null,
+  p_description text default null,
+  p_object_path text default null,
+  p_media_kind text default null,
+  p_mime_type text default null,
+  p_original_name text default null,
+  p_size_bytes bigint default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+declare
+  v_media public.media_submissions;
+  v_message public.messages;
+  v_post public.bulletin_posts;
+begin
+  if p_kind not in ('message', 'post') then
+    raise exception using errcode = '22023', message = 'invalid community submission kind';
+  end if;
+  if p_sender is null or char_length(btrim(p_sender)) not between 1 and 100 then
+    raise exception using errcode = '22023', message = 'invalid sender';
+  end if;
+  if p_content is null or char_length(btrim(p_content)) not between 1 and 1000 then
+    raise exception using errcode = '22023', message = 'invalid content';
+  end if;
+  if p_birthday_person is not null and char_length(btrim(p_birthday_person)) not between 1 and 100 then
+    raise exception using errcode = '22023', message = 'invalid birthday person';
+  end if;
+  if p_description is not null and char_length(p_description) > 1000 then
+    raise exception using errcode = '22023', message = 'invalid description';
+  end if;
+
+  if p_object_path is null then
+    if p_media_kind is not null or p_mime_type is not null or p_original_name is not null or p_size_bytes is not null then
+      raise exception using errcode = '22023', message = 'incomplete media metadata';
+    end if;
+  else
+    if p_media_kind not in ('image', 'video', 'audio')
+      or p_mime_type is null or char_length(p_mime_type) not between 1 and 255
+      or p_original_name is null or char_length(btrim(p_original_name)) not between 1 and 255
+      or p_size_bytes is null or p_size_bytes <= 0 or p_size_bytes > 52428800
+      or char_length(p_object_path) not between 1 and 500
+      or p_mime_type not in ('image/jpeg', 'image/png', 'image/webp', 'image/gif', 'video/mp4', 'video/webm', 'audio/webm', 'audio/mpeg', 'audio/mp4', 'audio/wav', 'audio/ogg')
+      or (p_media_kind = 'image' and (p_mime_type not like 'image/%' or p_object_path !~ '^images/'))
+      or (p_media_kind = 'video' and (p_mime_type not like 'video/%' or p_object_path !~ '^videos/'))
+      or (p_media_kind = 'audio' and (p_mime_type not like 'audio/%' or p_object_path !~ '^audios/'))
+      or (p_media_kind = 'video' and p_object_path !~ '^videos/')
+      or (p_media_kind = 'audio' and p_object_path !~ '^audios/')
+      or p_object_path !~ '^(images|videos|audios)/[0-9a-f-]+\.[a-z0-9]+$' then
+      raise exception using errcode = '22023', message = 'invalid media metadata';
+    end if;
+
+    insert into public.media_submissions (
+      sender, object_path, media_kind, mime_type, original_name, size_bytes,
+      birthday_person, description
+    ) values (
+      btrim(p_sender), p_object_path, p_media_kind, p_mime_type, btrim(p_original_name), p_size_bytes,
+      nullif(btrim(p_birthday_person), ''), nullif(btrim(p_description), '')
+    ) returning * into v_media;
+  end if;
+
+  if p_kind = 'message' then
+    insert into public.messages (sender, message, birthday_person, media_object_path)
+    values (btrim(p_sender), btrim(p_content), nullif(btrim(p_birthday_person), ''), p_object_path)
+    returning * into v_message;
+    return jsonb_build_object('message', to_jsonb(v_message), 'media_submission', to_jsonb(v_media));
+  end if;
+
+  insert into public.bulletin_posts (sender, message, media_object_path, birthday_person)
+  values (btrim(p_sender), btrim(p_content), p_object_path, nullif(btrim(p_birthday_person), ''))
+  returning * into v_post;
+  return jsonb_build_object('post', to_jsonb(v_post), 'media_submission', to_jsonb(v_media));
+end;
+$$;
+
+revoke execute on function public.create_community_submission(text, text, text, text, text, text, text, text, text, bigint) from public, anon, authenticated;
+grant execute on function public.create_community_submission(text, text, text, text, text, text, text, text, text, bigint) to service_role;
+
+commit;


### PR DESCRIPTION
## 概要

未認証の `POST /api/community` に関する本番 rate limit の proposal と、同じ投稿経路で確認された入力・補償削除の不備を整理します。production rate-limit provider、shared counter、migration、secret、deployment はこの PR では変更していません。

## 変更内容

- `POST /api/community` の write quota と production 適用境界を文書化
- 10 requests / 10 minutes、50 requests / 24 hours を初期 proposal として記録
- quota 超過時の HTTP `429`、`Retry-After`、safe error envelope、ログ出力境界を記録
- 長すぎる任意項目を `400` として拒否
- 空白または 255 文字超の filename を Storage upload 前に拒否
- RPC がエラーを返す場合と transport failure で reject する場合の両方で、アップロード済み object を補償削除
- 補償削除が実際に upload した path を対象にする regression test を追加

## 検証

- `npm run typecheck`: 成功
- community route / community media targeted tests: 成功（6/6）
- `git diff --check`: 成功
- `verify`: success
- `Vercel Preview Comments`: success
- `Greptile Review`: success
- `cubic · AI code reviewer`: success

## 未完了・範囲外

- production platform/provider と cross-instance shared counter は未設定
- staging または production での rate-limit successful evidence は未取得
- production の RPC migration、secret、scheduler、外部 provider configuration は未実施
- request body limit と large-media deployment boundary は、現行 platform の実設定確認が必要

## References

Refs #2



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a server-side community submission transaction path, tightens input and media validation, and documents a proposed production rate-limit boundary.
- Adds `POST /api/community` and a service-only transactional submission RPC.
- Routes message media submissions through the server and standardizes community media validation.
- Adds compensating deletion for explicit RPC and metadata-insert errors.
- Adds route, component, media, and migration regression tests.
- Documents proposed anonymous-post quotas and the production infrastructure still required.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because an RPC transport rejection can still leave an uploaded community-media object without matching submission metadata.

The upload completes before the RPC call, but rejected RPC promises bypass the only cleanup branch; the new test explicitly preserves that behavior, so the previously reported orphaned-object failure remains outstanding.

**Files Needing Attention:** lib/community/server.ts, __tests__/api/community-route.test.ts
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/api/community/route.ts | Adds the multipart community submission endpoint with pre-upload text, filename, MIME-type, and media validation. |
| lib/community/server.ts | Implements upload-plus-transaction submission handling and compensating cleanup for explicit RPC errors. |
| supabase/migrations/20260901000000_add_community_submission_rpc.sql | Adds a constrained, service-only transactional RPC for creating community submissions and optional media metadata. |
| components/community/MessageForm.tsx | Moves message submissions containing media onto the server-side transaction endpoint. |
| lib/supabase/communityMedia.ts | Tightens metadata validation and removes uploaded objects when metadata insertion fails. |
| docs/community-rate-limit-production-proposal.md | Documents proposed production quotas, response behavior, privacy boundaries, and required external infrastructure. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Browser
    participant API as POST /api/community
    participant Storage
    participant RPC as create_community_submission
    participant DB
    Browser->>API: Multipart submission
    API->>API: Validate fields and media
    API->>Storage: Upload object
    Storage-->>API: Upload result
    API->>RPC: Create submission and metadata
    RPC->>DB: Transactional inserts
    DB-->>RPC: Commit or rollback
    RPC-->>API: Data or explicit error
    alt Success
        API-->>Browser: 201
    else Explicit RPC error
        API->>Storage: Remove uploaded object
        API-->>Browser: 500
    else Transport rejection
        API-->>Browser: 500
    end
```
</details>

<sub>Reviews (5): Last reviewed commit: ["fix: RPC通信不確実時のメディア削除を避ける"](https://github.com/hayato-shino05/omoide/commit/b51146031aa07f46f89306756221db9a8a2608d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59176037)</sub>

<!-- /greptile_comment -->