### PR TITLE
監査済み実装ロードマップを1.0.0へ再適用する

### DIFF
--- a/docs/OMOIDE_IMPLEMENTATION_PLAN.md
+++ b/docs/OMOIDE_IMPLEMENTATION_PLAN.md
@@ -26,9 +26,9 @@
 | 完了 | #40 | Bulletin Board の Keepsake Export | 完了 | Issue #40 は クローズ済み、PR #73 は マージ済み です。native browser print による公開投稿の出力が リポジトリ 範囲 で完了しています。 |
 | 完了 | #37 | Reminder 契約 | 完了 | Issue #37 は クローズ済み、PR #50 は マージ済み です。本番 接続は対象外です。 |
 | 継続中 | #44 / F6 | Time Capsule open tracking | 本番 gate blocked | PR #75/#78 の実装・契約は マージ済みです。本番 schema、RLS、API の独立証跡が残っています。 |
-| 継続中 | #2 | 匿名コミュニティ投稿と upload 経路 | リポジトリ 実装は大部分完了、本番証跡待ち | PR #77/#79 は未 merge です。本番 境界の確認項目が複数残っています。 |
+| 継続中 | #2 | 匿名コミュニティ投稿と upload 経路 | リポジトリ 実装は大部分完了、本番証跡待ち | PR #81 は `70f68a0` として docs-only proposal を merge 済みです。PR #77/#79 は runtime を含む Draft のまま未 merge で、本番境界の確認項目が複数残っています。 |
 | 計画 | F2 | Keepsake Export | リポジトリ 範囲 完了、証跡整理中 | 公開投稿の native print 実装は #40 で完了しました。 |
-| 計画 | F5 | Omikuji History/Streak | planned / not evidenced | #43 の契約は証跡があります。ロードマップ上の独立した F5 完了証跡は追加しません。 |
+| 完了 | F5 | Omikuji History/Streak | リポジトリ範囲 complete | Issue #43 はクローズ済み、PR #74 はマージ済みです。repository implementation・contract・tests の範囲は完了しています。独立した roadmap-level evidence は別途取得していません。 |
 | 継続中 | TD | 選択的 technical debt | 一部完了 | caller と 契約 を確認した範囲だけ整理します。 |
 
 ## 3. 完了した リポジトリ 範囲
@@ -37,10 +37,10 @@
 
 - Issue #45 は クローズ済み です。
 - PR #71 は マージ済み です。
-- `generateVideoThumbnail` と `uploadThumbnail` の実利用を維持しました。
-- caller を確認できない `generateThumbnailFromUrl` のみ削除しました。
+- `generateVideoThumbnail` と `uploadThumbnail` は caller が確認できないまま維持されています。
+- caller を確認できない export のうち、`generateThumbnailFromUrl` のみ削除されました。
 - `countdownHeading` と共有型の `thumbnail_url` は利用中のため維持しました。
-- この項目は リポジトリ 範囲 complete です。本番 readiness や広範囲の cleanup 完了を意味しません。
+- この項目はリポジトリ範囲 complete です。本番対応準備や広範囲の cleanup 完了を意味しません。
 
 ### 3.2 #43: localStorage による Omikuji history/streak
 
@@ -55,15 +55,12 @@
 
 ### 3.3 #40 / F2: native browser print による Keepsake Export
 
-- Issue #40 は クローズ済み です。
-- PR #73 は マージ済み です。
-- Bulletin Board の現在表示中の公開投稿だけを native browser print layout として出力します。
-- 出力対象は sender、created_at、message、許可済み `media_url` に限定します。
-- Time Capsule、未表示データ、非公開データは取得・出力しません。
-- JA/EN、empty state、popup blocked、construction failure の feedback と regression test があります。
-- 元画面の state、animation、本番 data は変更しません。
-
-PR #73 のレビュー記録には、source/comment 上の画像 decode 待機に bounded failure path が不足する旨の timeout wording が残っています。手元で追加の manual 証跡 は確認していないため、Keepsake Export の完了条件にその 証跡 を含めず、実装・test・CI が確認できる範囲だけを完了とします。
+- Issue #40 はクローズ済み、PR #73 はマージ済みです。Issue と PR の記録では Bulletin Board の現在表示中の公開投稿を対象としています。
+- 現在のリポジトリ実装では、`components/community/TimeCapsule.tsx` の `handleExport` が、開封済み Time Capsule の print window に `populateKeepsakePrintDocument` を適用します。
+- print document に出力する値は `title`、`eventDate`、`sender`、`message`、任意の `photoUrl` です。`created_at` や `media_url` はこの実装の出力項目ではありません。
+- `photoUrl` がある場合は画像を追加し、`waitForKeepsakePhoto` で読み込み・decode を待ってから print します。画像がない場合も print できます。
+- JA/EN の title/date 表示、popup blocked、construction failure、画像の読み込み・decode failure に対する feedback と regression test があります。
+- 元画面の state、animation、本番 data は変更しません。Issue #40 / PR #73 の Bulletin Board framing と、現行 source の Time Capsule export 実装は別の evidence として扱います。
 
 ### 3.4 #37 / R0・R1・R2: Reminder 契約
 
@@ -86,7 +83,7 @@ Issue #37 は クローズ済み、PR #50 は マージ済み です。リポジ
 
 ## 4. #44 / F6: Open Tracking
 
-Issue #44 は open のままです。PR #75/#78 の リポジトリ 実装 と privacy 契約は マージ済みですが、本番 readiness は未完了です。
+Issue #44 は open のままです。PR #75/#78 のリポジトリ実装と privacy 契約はマージ済みですが、本番対応準備は未完了です。PR #75 の古い invite-token GET tracking は、Issue #44 の訂正と契約・PR #78 によって supersede されています。現行契約が追跡するのは POST access route だけで、通常の invite-token GET は対象外です。
 
 ### 確定した tracking boundary
 
@@ -107,29 +104,36 @@ Issue #44 は open のままです。PR #75/#78 の リポジトリ 実装 と p
 
 ## 5. #2: 匿名コミュニティ投稿と upload
 
-Issue #2 は open です。local code / 契約 work は大部分完了していますが、PR #77 と PR #79 は未 merge です。PR の CI 結果を 本番 proof として扱いません。
+Issue #2 は open です。PR #81 は `70f68a0` として merge 済みの docs-only proposal です。一方、PR #77 は runtime と migration/test を含む Draft のまま、PR #79 も runtime 側の Draft のままで、いずれも merge されていません。PR の CI 結果を本番 proof として扱いません。
 
-### リポジトリ で確認できる範囲
+### #2 で観察できた evidence
+
+#### リポジトリの実装・契約
 
 - 匿名ロールが作成できる操作は、許可されたメッセージ、メディア、ギフト、チャットに限定します。
 - 匿名ロールによる誕生日データの作成・更新・削除を許可しません。
 - 投稿済みのメッセージ、メディア、ギフト、音声、動画、掲示板投稿、返信、チャットの更新・削除を匿名アクセスから遮断します。
 - `bulletin_posts` の公開 `UPDATE` 権限を廃止し、いいね操作は既存 RPC 経由にします。
 - ブラウザからの直接 upload と API 経由 upload を一つの方針に統一します。
-- upload 入力、MIME、容量、保持期間、通報・モデレーション方針を リポジトリ 契約 と test で確認します。
+- upload 入力、MIME、容量、保持期間、通報・モデレーション方針をリポジトリ契約と test で確認します。
 
-### 残る 本番 / independent 証跡
+#### 本番で観察した read-only snapshot
 
-- 本番 Storage の公開状態と `storage.objects` policy
-- 必要最小限の匿名 upload 権限
-- 本番 RLS migration / apply の確認
-- external scheduler の成功実行
-- scheduler secret の設定と failure 証跡
-- rate-limit enforcement
-- body-limit と large-media boundary
-- PR #77 と PR #79 の merge 状態
+- 現 MCP session の read-only catalog では、`exam` が `ACTIVE_HEALTHY` で、community 関連 table の RLS、匿名 role の確認範囲における `SELECT` / `INSERT`、`birthdays` の `SELECT` のみを確認しました。
+- `community-media` は public、50 MiB、image/video/audio allowlist、`avatars` は public、5 MiB、JPEG/PNG/WebP/GIF でした。確認した `storage.objects` policy は匿名 `SELECT` / `INSERT` のみで、`UPDATE` / `DELETE` は確認されませんでした。
+- healthcheck workflow の schedule は毎日 1 回（`0 0 * * *`、`Asia/Tokyo`）です。直近 5 run は失敗し、最新 run は REST HTTP `401` でしたが、secret はログ上 `***` にマスクされ、失敗 workflow/log の可視性は確認できました。
+- これらは現 MCP session で観察した catalog、policy、schedule、masking/failure visibility の snapshot であり、独立 identity による attestation ではありません。
 
-本番 independent attestation、RPC migration/apply、scheduler success、secret/failure 証跡、rate-limit enforcement、body-limit/large-media boundary が確認できるまで、Issue #2 を complete としません。CI が green であっても、本番 proof の代わりにはなりません。
+### 残る gate
+
+- independent identity による本番 Storage/RLS/catalog attestation
+- 本番の `create_community_submission` RPC に関する migration/apply、routine privilege、実行確認
+- default branch からの scheduler の successful production run
+- scheduler secret の target mapping と成功経路の確認（masking/failure visibility は観察済み）
+- production rate-limit enforcement
+- platform body-limit と large-media deployment boundary の決定・確認
+
+上記 gate と、PR #77/#79 の merge 状態が解消されるまで、Issue #2 を complete としません。PR #81 の docs-only merge や CI が green であっても、本番 acceptance の代わりにはなりません。
 
 ## 6. ロードマップ
 
@@ -155,21 +159,22 @@ Issue #2 は open です。local code / 契約 work は大部分完了してい�
 - R0 は `birthday` / `capsule_unlock`、`recipientRef`、`in_app`、opt-in、IANA/UTC を確定済みです。
 - R1 は notification log schema proposal と privacy/retention 制約を リポジトリ に保持します。
 - R2 は bounded retry、idempotency、opt-out、`failed` state を test で確認します。
-- 本番 scheduler、migration、provider 実送信は別の 本番 readiness 範囲 とします。
+- 本番 scheduler、migration、provider 実送信は別の本番対応準備の範囲とします。
 
 ### Batch 3: Keepsake Export
 
-**ステータス:** F2 リポジトリ 範囲 complete。Issue #40 クローズ済み、PR #73 マージ済み。
+**ステータス:** F2 の Issue #40 はクローズ済み、PR #73 はマージ済みです。現行リポジトリでは、開封済み Time Capsule の export 実装を確認しています。
 
-- native browser print layout を使います。
-- 現在表示中で、ユーザーが閲覧できる公開投稿だけを出力します。
-- source/comment に残る timeout wording については、追加 manual 証跡 がないため未検証として扱います。
+- `handleExport` が `populateKeepsakePrintDocument` を呼び、native browser print layout を構築します。
+- 出力項目は `title`、`eventDate`、`sender`、`message`、任意の `photoUrl` です。`created_at` は使用しません。
+- `waitForKeepsakePhoto` が画像の読み込み・decode を待ち、画像がない場合も export を継続します。
+- Issue #40 / PR #73 に記録された Bulletin Board の公開投稿 export と、現行 source にある Time Capsule export は同一視せず、各 evidence の対象を分けて記録します。
 
 ### Batch 4: Contributor Prompts と Omikuji History
 
 **Contributor Prompts:** リポジトリ 実装・test 済みです。
 
-**F5 Omikuji History/Streak:** planned / not evidenced とします。#43 の browser-local history/streak 契約は完了していますが、この roadmap の F5 を別項目として complete とする独立 証跡 はありません。
+**F5 Omikuji History/Streak:** リポジトリ範囲 complete です。Issue #43 はクローズ済み、PR #74 はマージ済みで、browser-local history/streak の repository implementation・contract・tests が完了しています。独立した roadmap-level evidence は別途取得していません。
 
 ### Batch 5: Open Tracking と technical debt
 
@@ -195,5 +200,5 @@ Issue #2 は open です。local code / 契約 work は大部分完了してい�
 - Keepsake Export は閲覧権限のある表示中データだけを出力する。
 - #44 の 本番 schema/RLS/API 証跡 が揃っている。
 - #2 の PR、本番 attestation、RPC migration/apply、scheduler success、secret/failure、rate-limit、body-limit/large-media boundary が確認できている。
-- F5 は 証跡 が追加されるまで planned / not evidenced のままにする。
+- F5 は Issue #43 と PR #74 が示す repository implementation・contract・tests の範囲で complete とします。独立した roadmap-level evidence は別途取得していません。
 - targeted test、全体 test、build、lint、typecheck、`git diff --check` の結果を実行範囲とともに記録している。


### PR DESCRIPTION
## 概要

PR #82 が base との競合で更新・マージできないため、`1.0.0`（`70f68a0`）から docs-only の新規ブランチを作成し、監査済みロードマップを再適用しました。既存の PR #82、Issue #2、Issue #44 は変更・終了していません。

## 反映内容

- F5 / Issue #43 を repository implementation・contract・tests の範囲で complete と記録し、planned / not evidenced の誤記を除去
- PR #81（`70f68a0`）の docs-only merge と、runtime を含む Draft の PR #77/#79 を区別
- 観察済み production snapshot と、independent attestation / successful run など未完了の gate を分離
- Issue #44 の訂正と PR #78 が PR #75 の古い GET tracking 説明を supersede したこと、現行 tracking が POST-only であることを明記
- Issue #40 の Bulletin Board 記録と、現行 Time Capsule export（`title`、`eventDate`、`sender`、`message`、任意の `photoUrl`）を分離
- #45 について `generateVideoThumbnail` / `uploadThumbnail` の caller 未確認と、削除済み `generateThumbnailFromUrl` を正確に記録
- 文字化けを含まない日本語文書に更新

## 実装チェックリスト

- [x] `docs/OMOIDE_IMPLEMENTATION_PLAN.md` のみを変更
- [x] application code、migration、test を変更しない
- [x] PR #82 の既存ブランチを上書きしない

## 検証チェックリスト

- [x] `git diff --check` 相当の文書内容確認
- [x] base SHA が `70f68a013d7a12356f68f64a7111296138274244` であることを確認
- [x] 文字化けがないことを確認
- [x] remote checks と review threads を確認した

## テスト計画

docs-only のため、アプリケーション test は変更していません。`git diff --check`、remote `verify`、Vercel Preview Comments、review threads を確認しました。typecheck は checkout の既存 script が利用できない環境だったため未実行です。

## 未確認事項

production readiness、独立 identity による attestation、migration/apply、scheduler の successful run、rate-limit enforcement、body-limit / large-media boundary は本 PR の範囲外であり、Issue #2 / #44 の未完了 gate としてロードマップに保持しています。

## References

Refs #2

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This docs-only PR reapplies the audited implementation roadmap and updates completion, production-evidence, export, and tracking descriptions.
- Marks F5 complete within the repository implementation, contract, and test scope.
- Separates observed production snapshots from outstanding independent readiness gates.
- Distinguishes Bulletin Board records from the current Time Capsule export implementation.
- Clarifies intended POST-only open tracking, although that description does not match the current GET route.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The docs-only PR is safe to merge after correcting its non-blocking but materially inaccurate description of the current invite-token GET tracking behavior.

The current GET route and its regression test still call `recordFirstOpen` for unlocked invite-token requests, contradicting the roadmap’s POST-only implementation claim.

**Files Needing Attention:** docs/OMOIDE_IMPLEMENTATION_PLAN.md
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/OMOIDE_IMPLEMENTATION_PLAN.md | Broadly improves roadmap evidence boundaries, but incorrectly states that current invite-token GET requests do not record first-open tracking. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
docs/OMOIDE_IMPLEMENTATION_PLAN.md:86
**GET追跡の記述が実装と不一致**

現在の GET handler は、unlock 済み capsule が `x-time-capsule-invite-token` header 付きで取得されると `recordFirstOpen` を呼びます。この箇所を POST-only と記述すると、ロードマップを参照する保守担当者が現在の privacy boundary を誤認します。

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["監査済み実装ロードマップを更新する"](https://github.com/hayato-shino05/omoide/commit/aaf28e3c911928809e4b55cecfac7506234361ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59279781)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->