### PR TITLE
invite-token GET の open tracking を契約範囲外にする

### DIFF
--- a/__tests__/api/time-capsules-access-route.test.ts
+++ b/__tests__/api/time-capsules-access-route.test.ts
@@ -60,6 +60,17 @@ describe('POST /api/time-capsules/access', () => {
     expect(await response.json()).toEqual({ data: { id: 1, isUnlocked: false } })
   })
 
+  it('records the first open for an unlocked access-code access', async () => {
+    const data = { id: 1, isUnlocked: true, message: '本文' }
+    server.serializeCapsule.mockResolvedValue(data)
+
+    const response = await POST(request({ accessCode: '123456' }))
+
+    expect(response.status).toBe(200)
+    expect(server.recordFirstOpen).toHaveBeenCalledWith({}, { id: 1 })
+    expect(await response.json()).toEqual({ data })
+  })
+
   it('rejects a request without an access code', async () => {
     const response = await POST(request({}))
 

--- a/__tests__/api/time-capsules-id-route.test.ts
+++ b/__tests__/api/time-capsules-id-route.test.ts
@@ -75,16 +75,4 @@ describe('GET /api/time-capsules/[id]', () => {
     expect(server.recordFirstOpen).not.toHaveBeenCalled()
   })
 
-  it('returns unlocked invite content when first-open tracking fails', async () => {
-    const data = { id: 1, isUnlocked: true, message: '本文' }
-    server.serializeCapsule.mockResolvedValue(data)
-    server.recordFirstOpen.mockRejectedValue(new Error('database unavailable'))
-
-    const response = await GET(request({ 'x-time-capsule-invite-token': 'a'.repeat(32) }), {
-      params: Promise.resolve({ id: '1' }),
-    })
-
-    expect(response.status).toBe(200)
-    expect(await response.json()).toEqual({ data })
-  })
 })

--- a/__tests__/api/time-capsules-id-route.test.ts
+++ b/__tests__/api/time-capsules-id-route.test.ts
@@ -43,7 +43,7 @@ beforeEach(() => {
 })
 
 describe('GET /api/time-capsules/[id]', () => {
-  it('records the first open for an unlocked invite access', async () => {
+  it('does not record an unlocked invite GET', async () => {
     const data = { id: 1, isUnlocked: true, message: '本文' }
     server.serializeCapsule.mockResolvedValue(data)
 
@@ -52,7 +52,7 @@ describe('GET /api/time-capsules/[id]', () => {
     })
 
     expect(response.status).toBe(200)
-    expect(server.recordFirstOpen).toHaveBeenCalledWith({}, row)
+    expect(server.recordFirstOpen).not.toHaveBeenCalled()
     expect(await response.json()).toEqual({ data })
   })
 

--- a/app/api/time-capsules/[id]/route.ts
+++ b/app/api/time-capsules/[id]/route.ts
@@ -6,7 +6,6 @@ import {
   findByInviteToken,
   parseId,
   parseInviteToken,
-  recordFirstOpen,
   requireUser,
   serializeCapsule,
   createServiceClient,
@@ -23,15 +22,6 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     if (inviteToken) {
       const { client, row } = await findByInviteToken(parseInviteToken(inviteToken), id)
       const data = await serializeCapsule(client, row)
-      if (data.isUnlocked === true) {
-        try {
-          await recordFirstOpen(client, row)
-        } catch (error) {
-          console.warn('[TimeCapsule] first-open tracking failed', {
-            error: error instanceof Error ? error.name : 'unknown_error',
-          })
-        }
-      }
       return Response.json(
         { data },
         { headers: { 'Cache-Control': 'no-store', 'Referrer-Policy': 'no-referrer' } }


### PR DESCRIPTION
## 概要

現行 contract と runtime の差異を修正し、invite-token の通常 GET では `recordFirstOpen` を呼ばないようにしました。access-code の POST は従来どおり first-open tracking を維持します。

## 変更内容

- invite-token GET から `recordFirstOpen` 呼び出しを削除
- unlocked invite GET が tracking を行わない regression test に更新
- unlocked access-code POST が tracking を継続する regression test を追加
- `docs/`、migration、production schema/RLS/API は変更なし

## Implementation

- [x] contract が定める invite-token GET の tracking 外範囲を runtime に反映
- [x] access-code POST の tracking 境界を維持
- [x] 変更範囲を route と regression test に限定

## Verification

- [x] targeted tests: 2 files / 10 tests pass
- [x] `npm run typecheck` pass
- [x] `npm run lint` pass
- [x] `git diff --check` pass
- [x] `gitnexus detect_changes` で変更 3 files、risk medium を確認
- [ ] CI と review の最終確認

## Test plan

unlocked invite-token GET が content を返しつつ `recordFirstOpen` を呼ばないこと、および unlocked access-code POST が `recordFirstOpen` を呼ぶことを確認します。

## 未検証

production schema、RLS、API の独立 verification はこの PR の範囲外です。

## References

Refs #44

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns invite-token GET with the contract so it no longer records first-open tracking; access-code POST still does. Refs #44.

- Removes the `recordFirstOpen` call and import from the invite-token GET route.
- Updates regression tests to assert no tracking on invite GET, tracking on access-code POST, and removes the now-obsolete first-open failure test.

<sup>Written for commit 1a06763f028c89a0d8957e63a9296157dccc3e03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hayato-shino05/Omoide/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Aligns invite-token retrieval behavior with the open-tracking contract.
- Removes first-open tracking from normal invite-token GET requests.
- Retains first-open tracking for unlocked access-code POST requests.
- Updates route regression tests to enforce both boundaries.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/api/time-capsules/[id]/route.ts | Removes best-effort first-open tracking from the invite-token GET branch without altering lookup, serialization, response data, or response headers. |
| __tests__/api/time-capsules-id-route.test.ts | Updates the unlocked invite-token GET regression test to verify that first-open tracking is not invoked and removes the obsolete tracking-failure case. |
| __tests__/api/time-capsules-access-route.test.ts | Adds regression coverage confirming that unlocked access-code POST requests continue recording first-open state. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test: GET tracking failure の不要なテストを削除する"](https://github.com/hayato-shino05/omoide/commit/1a06763f028c89a0d8957e63a9296157dccc3e03) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59310053)</sub>

<!-- /greptile_comment -->