### PR TITLE
フォームのメディア検証とエラー表示を修正する

### DIFF
--- a/__tests__/components/ContributorPromptButtons.test.tsx
+++ b/__tests__/components/ContributorPromptButtons.test.tsx
@@ -18,9 +18,14 @@ vi.mock('@/lib/hooks/useMessages', () => ({
 
 vi.mock('@/components/community/CameraCapture', () => ({
   CameraCapture: ({ onCapture }: { onCapture: (file: File) => void }) => (
-    <button type="button" onClick={() => onCapture(new File(['audio'], 'capture.mp3', { type: 'audio/mpeg' }))}>
-      mockCapture
-    </button>
+    <>
+      <button type="button" onClick={() => onCapture(new File(['image'], 'capture.png', { type: 'image/png' }))}>
+        mockValidCapture
+      </button>
+      <button type="button" onClick={() => onCapture(new File(['audio'], 'capture.mp3', { type: 'audio/mpeg' }))}>
+        mockInvalidCapture
+      </button>
+    </>
   ),
 }))
 
@@ -111,14 +116,32 @@ describe('Contributor prompts', () => {
     expect(uploadedFile.type).toBe('video/webm')
   })
 
-  it('closes the camera when captured media is rejected', () => {
+  it('closes the PostForm camera only after media validation succeeds', () => {
     render(<PostForm onSubmit={vi.fn()} />)
 
     fireEvent.click(screen.getByRole('button', { name: 'takePhoto' }))
-    expect(screen.getByRole('button', { name: 'mockCapture' })).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'mockCapture' }))
+    fireEvent.click(screen.getByRole('button', { name: 'mockValidCapture' }))
 
-    expect(screen.queryByRole('button', { name: 'mockCapture' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'mockValidCapture' })).not.toBeInTheDocument()
+  })
+
+  it('keeps the PostForm camera open when captured media is rejected', () => {
+    render(<PostForm onSubmit={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'takePhoto' }))
+    fireEvent.click(screen.getByRole('button', { name: 'mockInvalidCapture' }))
+
+    expect(screen.getByRole('button', { name: 'mockInvalidCapture' })).toBeInTheDocument()
+    expect(screen.getByText('fileTypeError')).toBeInTheDocument()
+  })
+
+  it('keeps the MessageForm camera open when captured media is rejected', () => {
+    render(<MessageForm />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'takePhoto' }))
+    fireEvent.click(screen.getByRole('button', { name: 'mockInvalidCapture' }))
+
+    expect(screen.getByRole('button', { name: 'mockInvalidCapture' })).toBeInTheDocument()
     expect(screen.getByText('fileTypeError')).toBeInTheDocument()
   })
 
@@ -131,6 +154,18 @@ describe('Contributor prompts', () => {
     fireEvent.click(screen.getByRole('button', { name: 'sendWish' }))
 
     await waitFor(() => expect(screen.getByText('sendMessageFailed')).toBeInTheDocument())
+  })
+
+  it('preserves a specific PostForm submission error', async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error('投稿内容が無効です'))
+    render(<PostForm onSubmit={onSubmit} />)
+
+    fireEvent.change(screen.getByPlaceholderText('yourName'), { target: { value: '花子' } })
+    fireEvent.change(screen.getByPlaceholderText('typeMessage'), { target: { value: 'おめでとう！' } })
+    fireEvent.click(screen.getByRole('button', { name: 'postMessage' }))
+
+    await waitFor(() => expect(screen.getByText('投稿内容が無効です')).toBeInTheDocument())
+    expect(screen.queryByText('genericError')).not.toBeInTheDocument()
   })
 
   it('rejects unsupported post media before upload', () => {

--- a/__tests__/components/ContributorPromptButtons.test.tsx
+++ b/__tests__/components/ContributorPromptButtons.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { useId } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { MessageForm } from '@/components/community/MessageForm'
 import PostForm from '@/components/community/PostForm'
@@ -17,16 +18,20 @@ vi.mock('@/lib/hooks/useMessages', () => ({
 }))
 
 vi.mock('@/components/community/CameraCapture', () => ({
-  CameraCapture: ({ onCapture }: { onCapture: (file: File) => void }) => (
-    <>
-      <button type="button" onClick={() => onCapture(new File(['image'], 'capture.png', { type: 'image/png' }))}>
-        mockValidCapture
-      </button>
-      <button type="button" onClick={() => onCapture(new File(['audio'], 'capture.mp3', { type: 'audio/mpeg' }))}>
-        mockInvalidCapture
-      </button>
-    </>
-  ),
+  CameraCapture: ({ onCapture }: { onCapture: (file: File) => void }) => {
+    const instance = useId()
+    return (
+      <>
+        <span data-testid="camera-instance">{instance}</span>
+        <button type="button" onClick={() => onCapture(new File(['image'], 'capture.png', { type: 'image/png' }))}>
+          mockValidCapture
+        </button>
+        <button type="button" onClick={() => onCapture(new File(['audio'], 'capture.mp3', { type: 'audio/mpeg' }))}>
+          mockInvalidCapture
+        </button>
+      </>
+    )
+  },
 }))
 
 vi.mock('@/components/ui/Icon', () => ({
@@ -125,24 +130,37 @@ describe('Contributor prompts', () => {
     expect(screen.queryByRole('button', { name: 'mockValidCapture' })).not.toBeInTheDocument()
   })
 
-  it('keeps the PostForm camera open when captured media is rejected', () => {
+  it('remounts the PostForm camera when captured media is rejected', () => {
     render(<PostForm onSubmit={vi.fn()} />)
 
     fireEvent.click(screen.getByRole('button', { name: 'takePhoto' }))
+    const previousInstance = screen.getByTestId('camera-instance').textContent
     fireEvent.click(screen.getByRole('button', { name: 'mockInvalidCapture' }))
 
     expect(screen.getByRole('button', { name: 'mockInvalidCapture' })).toBeInTheDocument()
+    expect(screen.getByTestId('camera-instance').textContent).not.toBe(previousInstance)
     expect(screen.getByText('fileTypeError')).toBeInTheDocument()
   })
 
-  it('keeps the MessageForm camera open when captured media is rejected', () => {
+  it('remounts the MessageForm camera when captured media is rejected', () => {
     render(<MessageForm />)
 
     fireEvent.click(screen.getByRole('button', { name: 'takePhoto' }))
+    const previousInstance = screen.getByTestId('camera-instance').textContent
     fireEvent.click(screen.getByRole('button', { name: 'mockInvalidCapture' }))
 
     expect(screen.getByRole('button', { name: 'mockInvalidCapture' })).toBeInTheDocument()
+    expect(screen.getByTestId('camera-instance').textContent).not.toBe(previousInstance)
     expect(screen.getByText('fileTypeError')).toBeInTheDocument()
+  })
+
+  it('closes the MessageForm camera after media validation succeeds', () => {
+    render(<MessageForm />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'takePhoto' }))
+    fireEvent.click(screen.getByRole('button', { name: 'mockValidCapture' }))
+
+    expect(screen.queryByRole('button', { name: 'mockValidCapture' })).not.toBeInTheDocument()
   })
 
   it('shows an error when text-only message sending returns false', async () => {
@@ -156,31 +174,34 @@ describe('Contributor prompts', () => {
     await waitFor(() => expect(screen.getByText('sendMessageFailed')).toBeInTheDocument())
   })
 
-  it('shows a generic error when saving the sender name fails', async () => {
+  it('keeps the MessageForm success path when saving the sender name fails', async () => {
     sendMessage.mockResolvedValue(true)
     const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementationOnce(() => {
       throw new Error('storage quota exceeded')
     })
-    render(<MessageForm />)
+    const onSuccess = vi.fn()
+    render(<MessageForm onSuccess={onSuccess} />)
 
     fireEvent.change(screen.getByRole('textbox', { name: 'yourName' }), { target: { value: '花子' } })
     fireEvent.change(screen.getByRole('textbox', { name: 'messagePlaceholder' }), { target: { value: 'おめでとう！' } })
     fireEvent.click(screen.getByRole('button', { name: 'sendWish' }))
 
-    await waitFor(() => expect(screen.getByText('genericError')).toBeInTheDocument())
+    await waitFor(() => expect(onSuccess).toHaveBeenCalled())
+    expect(screen.getByRole('textbox', { name: 'messagePlaceholder' })).toHaveValue('')
+    expect(screen.queryByText('genericError')).not.toBeInTheDocument()
     setItemSpy.mockRestore()
   })
 
-  it('preserves a specific PostForm submission error', async () => {
-    const onSubmit = vi.fn().mockRejectedValue(new Error('投稿内容が無効です'))
+  it('shows a safe localized error when PostForm submission throws', async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error('database details'))
     render(<PostForm onSubmit={onSubmit} />)
 
     fireEvent.change(screen.getByPlaceholderText('yourName'), { target: { value: '花子' } })
     fireEvent.change(screen.getByPlaceholderText('typeMessage'), { target: { value: 'おめでとう！' } })
     fireEvent.click(screen.getByRole('button', { name: 'postMessage' }))
 
-    await waitFor(() => expect(screen.getByText('投稿内容が無効です')).toBeInTheDocument())
-    expect(screen.queryByText('genericError')).not.toBeInTheDocument()
+    await waitFor(() => expect(screen.getByText('genericError')).toBeInTheDocument())
+    expect(screen.queryByText('database details')).not.toBeInTheDocument()
   })
 
   it('rejects unsupported post media before upload', () => {

--- a/__tests__/components/ContributorPromptButtons.test.tsx
+++ b/__tests__/components/ContributorPromptButtons.test.tsx
@@ -156,6 +156,21 @@ describe('Contributor prompts', () => {
     await waitFor(() => expect(screen.getByText('sendMessageFailed')).toBeInTheDocument())
   })
 
+  it('shows a generic error when saving the sender name fails', async () => {
+    sendMessage.mockResolvedValue(true)
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementationOnce(() => {
+      throw new Error('storage quota exceeded')
+    })
+    render(<MessageForm />)
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'yourName' }), { target: { value: '花子' } })
+    fireEvent.change(screen.getByRole('textbox', { name: 'messagePlaceholder' }), { target: { value: 'おめでとう！' } })
+    fireEvent.click(screen.getByRole('button', { name: 'sendWish' }))
+
+    await waitFor(() => expect(screen.getByText('genericError')).toBeInTheDocument())
+    setItemSpy.mockRestore()
+  })
+
   it('preserves a specific PostForm submission error', async () => {
     const onSubmit = vi.fn().mockRejectedValue(new Error('投稿内容が無効です'))
     render(<PostForm onSubmit={onSubmit} />)

--- a/components/community/MessageForm.tsx
+++ b/components/community/MessageForm.tsx
@@ -35,6 +35,7 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
   const [uploadProgress, setUploadProgress] = useState(0)
   const [showCamera, setShowCamera] = useState(false)
+  const [cameraInstance, setCameraInstance] = useState(0)
   const [cameraMode, setCameraMode] = useState<'photo' | 'video'>('photo')
   const fileInputRef = useRef<HTMLInputElement>(null)
 
@@ -140,8 +141,7 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
         try {
           localStorage.setItem('birthday_user_name', sender.trim())
         } catch {
-          setError(t('genericError'))
-          return
+          console.warn('Failed to save sender name')
         }
         // 送信者名は保持し、メッセージのみクリアする
         setMessage('')
@@ -440,9 +440,14 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
       {/* カメラキャプチャ用モーダル */}
       {showCamera && (
         <CameraCapture
+          key={cameraInstance}
           mode={cameraMode}
           onCapture={(file) => {
-            if (handleSelectedFile(file)) setShowCamera(false)
+            if (handleSelectedFile(file)) {
+              setShowCamera(false)
+            } else {
+              setCameraInstance((current) => current + 1)
+            }
           }}
           onClose={() => setShowCamera(false)}
         />

--- a/components/community/MessageForm.tsx
+++ b/components/community/MessageForm.tsx
@@ -6,7 +6,7 @@ import { useMessages } from '@/lib/hooks/useMessages'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { CameraCapture } from './CameraCapture'
 import { ContributorPromptButtons } from './ContributorPromptButtons'
-import { getMediaKind, validateCommunityMediaFile } from '@/lib/validations/upload'
+import { getMediaKind, normalizeMediaFile, validateCommunityMediaFile } from '@/lib/validations/upload'
 import { Icon } from '@/components/ui/Icon'
 
 interface MessageFormProps {
@@ -37,12 +37,6 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
   const [showCamera, setShowCamera] = useState(false)
   const [cameraMode, setCameraMode] = useState<'photo' | 'video'>('photo')
   const fileInputRef = useRef<HTMLInputElement>(null)
-
-  const normalizeMediaFile = (file: File): File => {
-    const baseMimeType = file.type.split(';', 1)[0].trim().toLowerCase()
-    if (baseMimeType === file.type) return file
-    return new File([file], file.name, { type: baseMimeType, lastModified: file.lastModified })
-  }
 
   const handleSelectedFile = (file: File): boolean => {
     const normalizedFile = normalizeMediaFile(file)
@@ -116,7 +110,9 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
         return false
       }
     }
-    return sendMessage(payload.sender, payload.message, payload.birthdayPerson, payload.mediaObjectPath)
+    const success = await sendMessage(payload.sender, payload.message, payload.birthdayPerson, payload.mediaObjectPath)
+    if (!success) setError(t('sendMessageFailed'))
+    return success
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -146,11 +142,9 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
         setMessage('')
         removeFile()
         onSuccess?.()
-      } else {
-        setError(t('sendMessageFailed'))
       }
-    } catch {
-      setError(t('genericError'))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('genericError'))
     } finally {
       setIsSubmitting(false)
       setUploadProgress(0)
@@ -443,8 +437,7 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
         <CameraCapture
           mode={cameraMode}
           onCapture={(file) => {
-            handleSelectedFile(file)
-            setShowCamera(false)
+            if (handleSelectedFile(file)) setShowCamera(false)
           }}
           onClose={() => setShowCamera(false)}
         />

--- a/components/community/MessageForm.tsx
+++ b/components/community/MessageForm.tsx
@@ -137,7 +137,12 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
 
       if (success) {
         // 名前を共有ストレージに保存する（他のフォームと共用）
-        localStorage.setItem('birthday_user_name', sender.trim())
+        try {
+          localStorage.setItem('birthday_user_name', sender.trim())
+        } catch {
+          setError(t('genericError'))
+          return
+        }
         // 送信者名は保持し、メッセージのみクリアする
         setMessage('')
         removeFile()

--- a/components/community/PostForm.tsx
+++ b/components/community/PostForm.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect } from 'react'
 import { uploadCommunityMedia } from '@/lib/supabase/communityMedia'
-import { getMediaKind, validateCommunityMediaFile } from '@/lib/validations/upload'
+import { getMediaKind, normalizeMediaFile, validateCommunityMediaFile } from '@/lib/validations/upload'
 import { CameraCapture } from './CameraCapture'
 import { ContributorPromptButtons } from './ContributorPromptButtons'
 import { Icon } from '@/components/ui/Icon'
@@ -34,12 +34,6 @@ export default function PostForm({ onSubmit }: PostFormProps) {
   const [showCamera, setShowCamera] = useState(false)
   const [cameraMode, setCameraMode] = useState<'photo' | 'video'>('photo')
   const fileInputRef = useRef<HTMLInputElement>(null)
-
-  const normalizeMediaFile = (file: File): File => {
-    const baseMimeType = file.type.split(';', 1)[0].trim().toLowerCase()
-    if (baseMimeType === file.type) return file
-    return new File([file], file.name, { type: baseMimeType, lastModified: file.lastModified })
-  }
 
   const handleSelectedFile = (file: File): boolean => {
     const normalizedFile = normalizeMediaFile(file)
@@ -116,8 +110,8 @@ export default function PostForm({ onSubmit }: PostFormProps) {
       } else {
         setError(t('postFailed'))
       }
-    } catch {
-      setError(t('genericError'))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('genericError'))
     } finally {
       setSubmitting(false)
       setUploadProgress(0)
@@ -265,8 +259,7 @@ export default function PostForm({ onSubmit }: PostFormProps) {
         <CameraCapture
           mode={cameraMode}
           onCapture={(file) => {
-            handleSelectedFile(file)
-            setShowCamera(false)
+            if (handleSelectedFile(file)) setShowCamera(false)
           }}
           onClose={() => setShowCamera(false)}
         />

--- a/components/community/PostForm.tsx
+++ b/components/community/PostForm.tsx
@@ -32,6 +32,7 @@ export default function PostForm({ onSubmit }: PostFormProps) {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
   const [uploadProgress, setUploadProgress] = useState(0)
   const [showCamera, setShowCamera] = useState(false)
+  const [cameraInstance, setCameraInstance] = useState(0)
   const [cameraMode, setCameraMode] = useState<'photo' | 'video'>('photo')
   const fileInputRef = useRef<HTMLInputElement>(null)
 
@@ -103,15 +104,19 @@ export default function PostForm({ onSubmit }: PostFormProps) {
 
       if (success) {
         // 名前を共有ストレージに保存する（他のフォームと共用）
-        localStorage.setItem('birthday_user_name', author.trim())
+        try {
+          localStorage.setItem('birthday_user_name', author.trim())
+        } catch {
+          console.warn('Failed to save author name')
+        }
         // 投稿者名は保持し、本文のみクリアする
         setContent('')
         removeFile()
       } else {
         setError(t('postFailed'))
       }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : t('genericError'))
+    } catch {
+      setError(t('genericError'))
     } finally {
       setSubmitting(false)
       setUploadProgress(0)
@@ -257,9 +262,14 @@ export default function PostForm({ onSubmit }: PostFormProps) {
 
       {showCamera && (
         <CameraCapture
+          key={cameraInstance}
           mode={cameraMode}
           onCapture={(file) => {
-            if (handleSelectedFile(file)) setShowCamera(false)
+            if (handleSelectedFile(file)) {
+              setShowCamera(false)
+            } else {
+              setCameraInstance((current) => current + 1)
+            }
           }}
           onClose={() => setShowCamera(false)}
         />

--- a/lib/validations/upload.ts
+++ b/lib/validations/upload.ts
@@ -16,6 +16,12 @@ const COMMUNITY_MEDIA_TYPES = new Set([
 
 export type CommunityMediaKind = 'image' | 'video' | 'audio'
 
+export function normalizeMediaFile(file: File): File {
+  const baseMimeType = file.type.split(';', 1)[0].trim().toLowerCase()
+  if (baseMimeType === file.type) return file
+  return new File([file], file.name, { type: baseMimeType, lastModified: file.lastModified })
+}
+
 export function getMediaKind(mimeType: string): CommunityMediaKind | null {
   if (mimeType.startsWith('image/')) return 'image'
   if (mimeType.startsWith('video/')) return 'video'


### PR DESCRIPTION
## 概要

PR #84 の head `b54238067199bb26a6a7d0b5822f22fdc725dc2f` から分岐し、未解決だったフォーム周辺のコード指摘だけを修正します。

## 変更内容

- `MessageForm` と `PostForm` は、`handleSelectedFile` の検証が成功した場合だけカメラを閉じます。拒否された撮影結果ではモーダルを残し、再試行できる状態にします。
- `MessageForm` の text-only 送信失敗はフォームへ表示し、メディア送信で返された具体的なエラーを汎用失敗文言で上書きしません。
- `MessageForm` と `PostForm` の `normalizeMediaFile` を `lib/validations/upload.ts` の共有関数へ集約しました。`validateCommunityMediaFile` と `getMediaKind` のロジックおよびシグネチャは変更していません。
- `PostForm` の送信時は `Error` の具体的なメッセージを保持します。

## 受け入れ条件

- [x] 検証成功時だけ両フォームのカメラを閉じる。
- [x] 拒否時にカメラを閉じず、検証エラーを表示する。
- [x] 具体的な送信エラーを汎用エラーで上書きしない。
- [x] メディア正規化関数を一つの共有所有者へ集約する。
- [x] 回帰試験で上記の挙動を確認する。

## Issue レベルの実装

Issue #2 の「アップロード経路とファイル検証を統一する」に関係する、PR #84 の残存コード指摘を対象にしています。PostForm の大きな transaction lifecycle、legacy anon grants、本番 DB/RLS、rate-limit provider、platform body limit、scheduler は変更しません。

## 検証

- `npm test -- --run __tests__/components/ContributorPromptButtons.test.tsx __tests__/lib/upload-validation.test.ts` を実行し、2 files / 17 tests が成功しました。
- `npm run typecheck` が成功しました。
- `npm run lint` が成功しました。
- `git diff --check` が成功しました。
- GitNexus の `detect_changes` は、共有検証モジュールに追加関数を置いたため `critical` を返しました。`getMediaKind` と `validateCommunityMediaFile` の実装は変更しておらず、期待した4ファイルの加算的な変更だけです。

## Test plan

- フォームのカメラ検証成功・拒否を確認する。
- text-only message の送信失敗を確認する。
- `PostForm` の具体的な送信エラーが保持されることを確認する。
- codec 付き MIME の正規化回帰を確認する。

## 範囲外

`docs/` は変更していません。本番 Supabase の RLS / Storage policy、legacy anon grants、共有 rate-limit provider、platform body limit、scheduler、PostForm の transaction lifecycle は対象外です。

## References

Refs #2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Addresses the remaining media-validation and error-handling feedback from Issue #2 in `MessageForm` and `PostForm` so rejected camera captures stay open for retry and submission failures show safe localized errors.

**Changes**
- Both forms remount `CameraCapture` on rejected captures and close it only after validation succeeds.
- `MessageForm` preserves media-specific errors from `sendMessage`, shows text-only send failures inline, and keeps the success path when saving the sender name to localStorage fails.
- `PostForm` replaces thrown submission errors with a generic localized message instead of exposing the original error.
- The duplicated `normalizeMediaFile` helpers are consolidated into `lib/validations/upload.ts`; `validateCommunityMediaFile` and `getMediaKind` are unchanged.
- Adds regression tests for camera retry behavior, rejected captures, sender-name storage failure, and safe submission errors.

<sup>Written for commit 38447041202d60ec5382685c365b2b26f1a83dd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hayato-shino05/Omoide/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR fixes form media validation and submission-error handling while consolidating MIME normalization.
- Keeps camera capture open and remounts it after rejected media, closing it only after successful validation.
- Preserves specific media submission errors and displays text-only send failures.
- Makes sender-name persistence failure non-fatal.
- Shares media MIME normalization between `MessageForm` and `PostForm`.
- Adds regression coverage for the corrected form behavior.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| components/community/MessageForm.tsx | Correctly isolates sender-name storage failure from successful submission and preserves validation-specific errors. |
| components/community/PostForm.tsx | Keeps rejected camera captures retryable, safely handles storage failure, and uses shared media normalization. |
| lib/validations/upload.ts | Adds the shared MIME normalization helper without changing existing validation behavior. |
| __tests__/components/ContributorPromptButtons.test.tsx | Adds focused regression tests for camera lifecycle, submission failures, storage failure, and MIME normalization. |

</details>

<sub>Reviews (3): Last reviewed commit: ["カメラ再起動と安全なエラー表示を修正する"](https://github.com/hayato-shino05/omoide/commit/38447041202d60ec5382685c365b2b26f1a83dd1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59316735)</sub>

<!-- /greptile_comment -->