### PR TITLE
カメラ撮影のメディア検証エラーを表示する

### DIFF
--- a/__tests__/components/ContributorPromptButtons.test.tsx
+++ b/__tests__/components/ContributorPromptButtons.test.tsx
@@ -18,9 +18,14 @@ vi.mock('@/lib/hooks/useMessages', () => ({
 
 vi.mock('@/components/community/CameraCapture', () => ({
   CameraCapture: ({ onCapture }: { onCapture: (file: File) => void }) => (
-    <button type="button" onClick={() => onCapture(new File(['audio'], 'capture.mp3', { type: 'audio/mpeg' }))}>
-      mockCapture
-    </button>
+    <>
+      <button type="button" onClick={() => onCapture(new File(['image'], 'capture.png', { type: 'image/png' }))}>
+        mockValidCapture
+      </button>
+      <button type="button" onClick={() => onCapture(new File(['audio'], 'capture.mp3', { type: 'audio/mpeg' }))}>
+        mockInvalidCapture
+      </button>
+    </>
   ),
 }))
 
@@ -111,14 +116,32 @@ describe('Contributor prompts', () => {
     expect(uploadedFile.type).toBe('video/webm')
   })
 
-  it('closes the camera when captured media is rejected', () => {
+  it('closes the PostForm camera only after media validation succeeds', () => {
     render(<PostForm onSubmit={vi.fn()} />)
 
     fireEvent.click(screen.getByRole('button', { name: 'takePhoto' }))
-    expect(screen.getByRole('button', { name: 'mockCapture' })).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'mockCapture' }))
+    fireEvent.click(screen.getByRole('button', { name: 'mockValidCapture' }))
 
-    expect(screen.queryByRole('button', { name: 'mockCapture' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'mockValidCapture' })).not.toBeInTheDocument()
+  })
+
+  it('keeps the PostForm camera open when captured media is rejected', () => {
+    render(<PostForm onSubmit={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'takePhoto' }))
+    fireEvent.click(screen.getByRole('button', { name: 'mockInvalidCapture' }))
+
+    expect(screen.getByRole('button', { name: 'mockInvalidCapture' })).toBeInTheDocument()
+    expect(screen.getByText('fileTypeError')).toBeInTheDocument()
+  })
+
+  it('keeps the MessageForm camera open when captured media is rejected', () => {
+    render(<MessageForm />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'takePhoto' }))
+    fireEvent.click(screen.getByRole('button', { name: 'mockInvalidCapture' }))
+
+    expect(screen.getByRole('button', { name: 'mockInvalidCapture' })).toBeInTheDocument()
     expect(screen.getByText('fileTypeError')).toBeInTheDocument()
   })
 
@@ -131,6 +154,18 @@ describe('Contributor prompts', () => {
     fireEvent.click(screen.getByRole('button', { name: 'sendWish' }))
 
     await waitFor(() => expect(screen.getByText('sendMessageFailed')).toBeInTheDocument())
+  })
+
+  it('preserves a specific PostForm submission error', async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error('投稿内容が無効です'))
+    render(<PostForm onSubmit={onSubmit} />)
+
+    fireEvent.change(screen.getByPlaceholderText('yourName'), { target: { value: '花子' } })
+    fireEvent.change(screen.getByPlaceholderText('typeMessage'), { target: { value: 'おめでとう！' } })
+    fireEvent.click(screen.getByRole('button', { name: 'postMessage' }))
+
+    await waitFor(() => expect(screen.getByText('投稿内容が無効です')).toBeInTheDocument())
+    expect(screen.queryByText('genericError')).not.toBeInTheDocument()
   })
 
   it('rejects unsupported post media before upload', () => {

--- a/__tests__/components/ContributorPromptButtons.test.tsx
+++ b/__tests__/components/ContributorPromptButtons.test.tsx
@@ -130,28 +130,28 @@ describe('Contributor prompts', () => {
     expect(screen.queryByRole('button', { name: 'mockValidCapture' })).not.toBeInTheDocument()
   })
 
-  it('remounts the PostForm camera when captured media is rejected', () => {
+  it('closes the PostForm camera and shows the validation error when capture is rejected', () => {
     render(<PostForm onSubmit={vi.fn()} />)
 
     fireEvent.click(screen.getByRole('button', { name: 'takePhoto' }))
-    const previousInstance = screen.getByTestId('camera-instance').textContent
     fireEvent.click(screen.getByRole('button', { name: 'mockInvalidCapture' }))
 
-    expect(screen.getByRole('button', { name: 'mockInvalidCapture' })).toBeInTheDocument()
-    expect(screen.getByTestId('camera-instance').textContent).not.toBe(previousInstance)
+    expect(screen.queryByRole('button', { name: 'mockInvalidCapture' })).not.toBeInTheDocument()
     expect(screen.getByText('fileTypeError')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'takePhoto' }))
+    expect(screen.getByRole('button', { name: 'mockInvalidCapture' })).toBeInTheDocument()
   })
 
-  it('remounts the MessageForm camera when captured media is rejected', () => {
+  it('closes the MessageForm camera and shows the validation error when capture is rejected', () => {
     render(<MessageForm />)
 
     fireEvent.click(screen.getByRole('button', { name: 'takePhoto' }))
-    const previousInstance = screen.getByTestId('camera-instance').textContent
     fireEvent.click(screen.getByRole('button', { name: 'mockInvalidCapture' }))
 
-    expect(screen.getByRole('button', { name: 'mockInvalidCapture' })).toBeInTheDocument()
-    expect(screen.getByTestId('camera-instance').textContent).not.toBe(previousInstance)
+    expect(screen.queryByRole('button', { name: 'mockInvalidCapture' })).not.toBeInTheDocument()
     expect(screen.getByText('fileTypeError')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'takePhoto' }))
+    expect(screen.getByRole('button', { name: 'mockInvalidCapture' })).toBeInTheDocument()
   })
 
   it('closes the MessageForm camera after media validation succeeds', () => {

--- a/__tests__/components/ContributorPromptButtons.test.tsx
+++ b/__tests__/components/ContributorPromptButtons.test.tsx
@@ -204,6 +204,18 @@ describe('Contributor prompts', () => {
     expect(screen.queryByText('database details')).not.toBeInTheDocument()
   })
 
+  it('shows a safe localized error when MessageForm submission throws', async () => {
+    sendMessage.mockRejectedValue(new Error('database details'))
+    render(<MessageForm />)
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'yourName' }), { target: { value: '花子' } })
+    fireEvent.change(screen.getByRole('textbox', { name: 'messagePlaceholder' }), { target: { value: 'おめでとう！' } })
+    fireEvent.click(screen.getByRole('button', { name: 'sendWish' }))
+
+    await waitFor(() => expect(screen.getByText('genericError')).toBeInTheDocument())
+    expect(screen.queryByText('database details')).not.toBeInTheDocument()
+  })
+
   it('rejects unsupported post media before upload', () => {
     render(<PostForm onSubmit={vi.fn()} />)
     const file = new File(['audio'], 'post.mp3', { type: 'audio/mpeg' })

--- a/__tests__/components/ContributorPromptButtons.test.tsx
+++ b/__tests__/components/ContributorPromptButtons.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { useId } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { MessageForm } from '@/components/community/MessageForm'
 import PostForm from '@/components/community/PostForm'
@@ -17,16 +18,20 @@ vi.mock('@/lib/hooks/useMessages', () => ({
 }))
 
 vi.mock('@/components/community/CameraCapture', () => ({
-  CameraCapture: ({ onCapture }: { onCapture: (file: File) => void }) => (
-    <>
-      <button type="button" onClick={() => onCapture(new File(['image'], 'capture.png', { type: 'image/png' }))}>
-        mockValidCapture
-      </button>
-      <button type="button" onClick={() => onCapture(new File(['audio'], 'capture.mp3', { type: 'audio/mpeg' }))}>
-        mockInvalidCapture
-      </button>
-    </>
-  ),
+  CameraCapture: ({ onCapture }: { onCapture: (file: File) => void }) => {
+    const instance = useId()
+    return (
+      <>
+        <span data-testid="camera-instance">{instance}</span>
+        <button type="button" onClick={() => onCapture(new File(['image'], 'capture.png', { type: 'image/png' }))}>
+          mockValidCapture
+        </button>
+        <button type="button" onClick={() => onCapture(new File(['audio'], 'capture.mp3', { type: 'audio/mpeg' }))}>
+          mockInvalidCapture
+        </button>
+      </>
+    )
+  },
 }))
 
 vi.mock('@/components/ui/Icon', () => ({
@@ -125,24 +130,37 @@ describe('Contributor prompts', () => {
     expect(screen.queryByRole('button', { name: 'mockValidCapture' })).not.toBeInTheDocument()
   })
 
-  it('keeps the PostForm camera open when captured media is rejected', () => {
+  it('remounts the PostForm camera when captured media is rejected', () => {
     render(<PostForm onSubmit={vi.fn()} />)
 
     fireEvent.click(screen.getByRole('button', { name: 'takePhoto' }))
+    const previousInstance = screen.getByTestId('camera-instance').textContent
     fireEvent.click(screen.getByRole('button', { name: 'mockInvalidCapture' }))
 
     expect(screen.getByRole('button', { name: 'mockInvalidCapture' })).toBeInTheDocument()
+    expect(screen.getByTestId('camera-instance').textContent).not.toBe(previousInstance)
     expect(screen.getByText('fileTypeError')).toBeInTheDocument()
   })
 
-  it('keeps the MessageForm camera open when captured media is rejected', () => {
+  it('remounts the MessageForm camera when captured media is rejected', () => {
     render(<MessageForm />)
 
     fireEvent.click(screen.getByRole('button', { name: 'takePhoto' }))
+    const previousInstance = screen.getByTestId('camera-instance').textContent
     fireEvent.click(screen.getByRole('button', { name: 'mockInvalidCapture' }))
 
     expect(screen.getByRole('button', { name: 'mockInvalidCapture' })).toBeInTheDocument()
+    expect(screen.getByTestId('camera-instance').textContent).not.toBe(previousInstance)
     expect(screen.getByText('fileTypeError')).toBeInTheDocument()
+  })
+
+  it('closes the MessageForm camera after media validation succeeds', () => {
+    render(<MessageForm />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'takePhoto' }))
+    fireEvent.click(screen.getByRole('button', { name: 'mockValidCapture' }))
+
+    expect(screen.queryByRole('button', { name: 'mockValidCapture' })).not.toBeInTheDocument()
   })
 
   it('shows an error when text-only message sending returns false', async () => {
@@ -156,31 +174,34 @@ describe('Contributor prompts', () => {
     await waitFor(() => expect(screen.getByText('sendMessageFailed')).toBeInTheDocument())
   })
 
-  it('shows a generic error when saving the sender name fails', async () => {
+  it('keeps the MessageForm success path when saving the sender name fails', async () => {
     sendMessage.mockResolvedValue(true)
     const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementationOnce(() => {
       throw new Error('storage quota exceeded')
     })
-    render(<MessageForm />)
+    const onSuccess = vi.fn()
+    render(<MessageForm onSuccess={onSuccess} />)
 
     fireEvent.change(screen.getByRole('textbox', { name: 'yourName' }), { target: { value: '花子' } })
     fireEvent.change(screen.getByRole('textbox', { name: 'messagePlaceholder' }), { target: { value: 'おめでとう！' } })
     fireEvent.click(screen.getByRole('button', { name: 'sendWish' }))
 
-    await waitFor(() => expect(screen.getByText('genericError')).toBeInTheDocument())
+    await waitFor(() => expect(onSuccess).toHaveBeenCalled())
+    expect(screen.getByRole('textbox', { name: 'messagePlaceholder' })).toHaveValue('')
+    expect(screen.queryByText('genericError')).not.toBeInTheDocument()
     setItemSpy.mockRestore()
   })
 
-  it('preserves a specific PostForm submission error', async () => {
-    const onSubmit = vi.fn().mockRejectedValue(new Error('投稿内容が無効です'))
+  it('shows a safe localized error when PostForm submission throws', async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error('database details'))
     render(<PostForm onSubmit={onSubmit} />)
 
     fireEvent.change(screen.getByPlaceholderText('yourName'), { target: { value: '花子' } })
     fireEvent.change(screen.getByPlaceholderText('typeMessage'), { target: { value: 'おめでとう！' } })
     fireEvent.click(screen.getByRole('button', { name: 'postMessage' }))
 
-    await waitFor(() => expect(screen.getByText('投稿内容が無効です')).toBeInTheDocument())
-    expect(screen.queryByText('genericError')).not.toBeInTheDocument()
+    await waitFor(() => expect(screen.getByText('genericError')).toBeInTheDocument())
+    expect(screen.queryByText('database details')).not.toBeInTheDocument()
   })
 
   it('rejects unsupported post media before upload', () => {

--- a/__tests__/components/ContributorPromptButtons.test.tsx
+++ b/__tests__/components/ContributorPromptButtons.test.tsx
@@ -156,6 +156,21 @@ describe('Contributor prompts', () => {
     await waitFor(() => expect(screen.getByText('sendMessageFailed')).toBeInTheDocument())
   })
 
+  it('shows a generic error when saving the sender name fails', async () => {
+    sendMessage.mockResolvedValue(true)
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementationOnce(() => {
+      throw new Error('storage quota exceeded')
+    })
+    render(<MessageForm />)
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'yourName' }), { target: { value: '花子' } })
+    fireEvent.change(screen.getByRole('textbox', { name: 'messagePlaceholder' }), { target: { value: 'おめでとう！' } })
+    fireEvent.click(screen.getByRole('button', { name: 'sendWish' }))
+
+    await waitFor(() => expect(screen.getByText('genericError')).toBeInTheDocument())
+    setItemSpy.mockRestore()
+  })
+
   it('preserves a specific PostForm submission error', async () => {
     const onSubmit = vi.fn().mockRejectedValue(new Error('投稿内容が無効です'))
     render(<PostForm onSubmit={onSubmit} />)

--- a/__tests__/lib/upload-validation.test.ts
+++ b/__tests__/lib/upload-validation.test.ts
@@ -1,5 +1,38 @@
 import { describe, expect, it } from 'vitest'
-import { getMediaKind, validateCommunityMediaFile } from '@/lib/validations/upload'
+import { getMediaKind, normalizeMediaFile, validateCommunityMediaFile } from '@/lib/validations/upload'
+
+describe('normalizeMediaFile', () => {
+  it('strips codec parameters from the MIME type', () => {
+    const file = new File(['video'], 'clip.webm', { type: 'video/webm; codecs=vp9' })
+
+    const normalized = normalizeMediaFile(file)
+
+    expect(normalized.type).toBe('video/webm')
+    expect(normalized).not.toBe(file)
+  })
+
+  it('returns the same File object when the MIME type is already clean', () => {
+    const file = new File(['image'], 'photo.png', { type: 'image/png' })
+
+    expect(normalizeMediaFile(file)).toBe(file)
+  })
+
+  it('normalizes uppercase and surrounding whitespace', () => {
+    const file = new File(['image'], 'photo.png', { type: 'image/png' })
+    Object.defineProperty(file, 'type', { configurable: true, value: ' IMAGE/PNG ' })
+
+    const normalized = normalizeMediaFile(file)
+
+    expect(normalized.type).toBe('image/png')
+    expect(normalized).not.toBe(file)
+  })
+
+  it('returns the same File object when the MIME type is empty', () => {
+    const file = new File(['data'], 'empty-type', { type: '' })
+
+    expect(normalizeMediaFile(file)).toBe(file)
+  })
+})
 
 describe('validateCommunityMediaFile', () => {
   it('accepts a supported image within the size limit', () => {

--- a/components/community/MessageForm.tsx
+++ b/components/community/MessageForm.tsx
@@ -35,6 +35,7 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
   const [uploadProgress, setUploadProgress] = useState(0)
   const [showCamera, setShowCamera] = useState(false)
+  const [cameraInstance, setCameraInstance] = useState(0)
   const [cameraMode, setCameraMode] = useState<'photo' | 'video'>('photo')
   const fileInputRef = useRef<HTMLInputElement>(null)
 
@@ -140,8 +141,7 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
         try {
           localStorage.setItem('birthday_user_name', sender.trim())
         } catch {
-          setError(t('genericError'))
-          return
+          console.warn('Failed to save sender name')
         }
         // 送信者名は保持し、メッセージのみクリアする
         setMessage('')
@@ -440,9 +440,14 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
       {/* カメラキャプチャ用モーダル */}
       {showCamera && (
         <CameraCapture
+          key={cameraInstance}
           mode={cameraMode}
           onCapture={(file) => {
-            if (handleSelectedFile(file)) setShowCamera(false)
+            if (handleSelectedFile(file)) {
+              setShowCamera(false)
+            } else {
+              setCameraInstance((current) => current + 1)
+            }
           }}
           onClose={() => setShowCamera(false)}
         />

--- a/components/community/MessageForm.tsx
+++ b/components/community/MessageForm.tsx
@@ -6,7 +6,7 @@ import { useMessages } from '@/lib/hooks/useMessages'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { CameraCapture } from './CameraCapture'
 import { ContributorPromptButtons } from './ContributorPromptButtons'
-import { getMediaKind, validateCommunityMediaFile } from '@/lib/validations/upload'
+import { getMediaKind, normalizeMediaFile, validateCommunityMediaFile } from '@/lib/validations/upload'
 import { Icon } from '@/components/ui/Icon'
 
 interface MessageFormProps {
@@ -37,12 +37,6 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
   const [showCamera, setShowCamera] = useState(false)
   const [cameraMode, setCameraMode] = useState<'photo' | 'video'>('photo')
   const fileInputRef = useRef<HTMLInputElement>(null)
-
-  const normalizeMediaFile = (file: File): File => {
-    const baseMimeType = file.type.split(';', 1)[0].trim().toLowerCase()
-    if (baseMimeType === file.type) return file
-    return new File([file], file.name, { type: baseMimeType, lastModified: file.lastModified })
-  }
 
   const handleSelectedFile = (file: File): boolean => {
     const normalizedFile = normalizeMediaFile(file)
@@ -116,7 +110,9 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
         return false
       }
     }
-    return sendMessage(payload.sender, payload.message, payload.birthdayPerson, payload.mediaObjectPath)
+    const success = await sendMessage(payload.sender, payload.message, payload.birthdayPerson, payload.mediaObjectPath)
+    if (!success) setError(t('sendMessageFailed'))
+    return success
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -146,11 +142,9 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
         setMessage('')
         removeFile()
         onSuccess?.()
-      } else {
-        setError(t('sendMessageFailed'))
       }
-    } catch {
-      setError(t('genericError'))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('genericError'))
     } finally {
       setIsSubmitting(false)
       setUploadProgress(0)
@@ -443,8 +437,7 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
         <CameraCapture
           mode={cameraMode}
           onCapture={(file) => {
-            handleSelectedFile(file)
-            setShowCamera(false)
+            if (handleSelectedFile(file)) setShowCamera(false)
           }}
           onClose={() => setShowCamera(false)}
         />

--- a/components/community/MessageForm.tsx
+++ b/components/community/MessageForm.tsx
@@ -137,7 +137,12 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
 
       if (success) {
         // 名前を共有ストレージに保存する（他のフォームと共用）
-        localStorage.setItem('birthday_user_name', sender.trim())
+        try {
+          localStorage.setItem('birthday_user_name', sender.trim())
+        } catch {
+          setError(t('genericError'))
+          return
+        }
         // 送信者名は保持し、メッセージのみクリアする
         setMessage('')
         removeFile()

--- a/components/community/MessageForm.tsx
+++ b/components/community/MessageForm.tsx
@@ -147,8 +147,8 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
         removeFile()
         onSuccess?.()
       }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : t('genericError'))
+    } catch {
+      setError(t('genericError'))
     } finally {
       setIsSubmitting(false)
       setUploadProgress(0)

--- a/components/community/MessageForm.tsx
+++ b/components/community/MessageForm.tsx
@@ -35,7 +35,6 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
   const [uploadProgress, setUploadProgress] = useState(0)
   const [showCamera, setShowCamera] = useState(false)
-  const [cameraInstance, setCameraInstance] = useState(0)
   const [cameraMode, setCameraMode] = useState<'photo' | 'video'>('photo')
   const fileInputRef = useRef<HTMLInputElement>(null)
 
@@ -440,14 +439,10 @@ export function MessageForm({ birthdayPerson, onSuccess }: MessageFormProps) {
       {/* カメラキャプチャ用モーダル */}
       {showCamera && (
         <CameraCapture
-          key={cameraInstance}
           mode={cameraMode}
           onCapture={(file) => {
-            if (handleSelectedFile(file)) {
-              setShowCamera(false)
-            } else {
-              setCameraInstance((current) => current + 1)
-            }
+            handleSelectedFile(file)
+            setShowCamera(false)
           }}
           onClose={() => setShowCamera(false)}
         />

--- a/components/community/PostForm.tsx
+++ b/components/community/PostForm.tsx
@@ -32,7 +32,6 @@ export default function PostForm({ onSubmit }: PostFormProps) {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
   const [uploadProgress, setUploadProgress] = useState(0)
   const [showCamera, setShowCamera] = useState(false)
-  const [cameraInstance, setCameraInstance] = useState(0)
   const [cameraMode, setCameraMode] = useState<'photo' | 'video'>('photo')
   const fileInputRef = useRef<HTMLInputElement>(null)
 
@@ -262,14 +261,10 @@ export default function PostForm({ onSubmit }: PostFormProps) {
 
       {showCamera && (
         <CameraCapture
-          key={cameraInstance}
           mode={cameraMode}
           onCapture={(file) => {
-            if (handleSelectedFile(file)) {
-              setShowCamera(false)
-            } else {
-              setCameraInstance((current) => current + 1)
-            }
+            handleSelectedFile(file)
+            setShowCamera(false)
           }}
           onClose={() => setShowCamera(false)}
         />

--- a/components/community/PostForm.tsx
+++ b/components/community/PostForm.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect } from 'react'
 import { uploadCommunityMedia } from '@/lib/supabase/communityMedia'
-import { getMediaKind, validateCommunityMediaFile } from '@/lib/validations/upload'
+import { getMediaKind, normalizeMediaFile, validateCommunityMediaFile } from '@/lib/validations/upload'
 import { CameraCapture } from './CameraCapture'
 import { ContributorPromptButtons } from './ContributorPromptButtons'
 import { Icon } from '@/components/ui/Icon'
@@ -34,12 +34,6 @@ export default function PostForm({ onSubmit }: PostFormProps) {
   const [showCamera, setShowCamera] = useState(false)
   const [cameraMode, setCameraMode] = useState<'photo' | 'video'>('photo')
   const fileInputRef = useRef<HTMLInputElement>(null)
-
-  const normalizeMediaFile = (file: File): File => {
-    const baseMimeType = file.type.split(';', 1)[0].trim().toLowerCase()
-    if (baseMimeType === file.type) return file
-    return new File([file], file.name, { type: baseMimeType, lastModified: file.lastModified })
-  }
 
   const handleSelectedFile = (file: File): boolean => {
     const normalizedFile = normalizeMediaFile(file)
@@ -116,8 +110,8 @@ export default function PostForm({ onSubmit }: PostFormProps) {
       } else {
         setError(t('postFailed'))
       }
-    } catch {
-      setError(t('genericError'))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('genericError'))
     } finally {
       setSubmitting(false)
       setUploadProgress(0)
@@ -265,8 +259,7 @@ export default function PostForm({ onSubmit }: PostFormProps) {
         <CameraCapture
           mode={cameraMode}
           onCapture={(file) => {
-            handleSelectedFile(file)
-            setShowCamera(false)
+            if (handleSelectedFile(file)) setShowCamera(false)
           }}
           onClose={() => setShowCamera(false)}
         />

--- a/components/community/PostForm.tsx
+++ b/components/community/PostForm.tsx
@@ -32,6 +32,7 @@ export default function PostForm({ onSubmit }: PostFormProps) {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
   const [uploadProgress, setUploadProgress] = useState(0)
   const [showCamera, setShowCamera] = useState(false)
+  const [cameraInstance, setCameraInstance] = useState(0)
   const [cameraMode, setCameraMode] = useState<'photo' | 'video'>('photo')
   const fileInputRef = useRef<HTMLInputElement>(null)
 
@@ -103,15 +104,19 @@ export default function PostForm({ onSubmit }: PostFormProps) {
 
       if (success) {
         // 名前を共有ストレージに保存する（他のフォームと共用）
-        localStorage.setItem('birthday_user_name', author.trim())
+        try {
+          localStorage.setItem('birthday_user_name', author.trim())
+        } catch {
+          console.warn('Failed to save author name')
+        }
         // 投稿者名は保持し、本文のみクリアする
         setContent('')
         removeFile()
       } else {
         setError(t('postFailed'))
       }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : t('genericError'))
+    } catch {
+      setError(t('genericError'))
     } finally {
       setSubmitting(false)
       setUploadProgress(0)
@@ -257,9 +262,14 @@ export default function PostForm({ onSubmit }: PostFormProps) {
 
       {showCamera && (
         <CameraCapture
+          key={cameraInstance}
           mode={cameraMode}
           onCapture={(file) => {
-            if (handleSelectedFile(file)) setShowCamera(false)
+            if (handleSelectedFile(file)) {
+              setShowCamera(false)
+            } else {
+              setCameraInstance((current) => current + 1)
+            }
           }}
           onClose={() => setShowCamera(false)}
         />

--- a/lib/validations/upload.ts
+++ b/lib/validations/upload.ts
@@ -16,6 +16,12 @@ const COMMUNITY_MEDIA_TYPES = new Set([
 
 export type CommunityMediaKind = 'image' | 'video' | 'audio'
 
+export function normalizeMediaFile(file: File): File {
+  const baseMimeType = file.type.split(';', 1)[0].trim().toLowerCase()
+  if (baseMimeType === file.type) return file
+  return new File([file], file.name, { type: baseMimeType, lastModified: file.lastModified })
+}
+
 export function getMediaKind(mimeType: string): CommunityMediaKind | null {
   if (mimeType.startsWith('image/')) return 'image'
   if (mimeType.startsWith('video/')) return 'video'


### PR DESCRIPTION
## 概要

カメラ撮影でメディア検証に失敗した際、全画面カメラモーダルの背後にエラーが隠れる問題を修正しました。

## 変更内容

- MessageForm と PostForm で撮影ファイルの検証後にカメラモーダルを閉じる
- フォーム上のローカライズ済みエラーを表示し、カメラボタンから再試行できる回帰テストを追加

## 検証

- 
> omoide@0.1.0 pretest
> node scripts/generate-data-manifest.mjs --check


> omoide@0.1.0 test
> vitest run __tests__/components/ContributorPromptButtons.test.tsx


 RUN  v4.1.11 D:/Github-Project/Omoide


 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  10:33:40
   Duration  25.30s (transform 170ms, setup 498ms, import 10.16s, tests 994ms, environment 12.79s)
- 
> omoide@0.1.0 pretypecheck
> npm run generate:data


> omoide@0.1.0 generate:data
> node scripts/generate-data-manifest.mjs --write


> omoide@0.1.0 typecheck
> tsc --noEmit
- 
> omoide@0.1.0 lint
> eslint


D:\Github-Project\Omoide\coverage\block-navigation.js
  1:1  warning  Unused eslint-disable directive (no problems were reported)

✖ 1 problem (0 errors, 1 warning)
  0 errors and 1 warning potentially fixable with the `--fix` option.
- 

Refs #2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows camera-capture media validation errors on the form instead of hiding them behind the fullscreen camera modal. `MessageForm` and `PostForm` close the modal after validating the captured file, display the localized error, and let the user retry from the camera button.

- Moves shared MIME normalization into `lib/validations/upload`.
- Submission failures show a generic localized error instead of leaking internal error text.
- `localStorage` failures when saving the sender name no longer fail a successful submission.

<sup>Written for commit 8b082b4d1e3e9a6d0db18dc12fe1eb0af55e3465. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hayato-shino05/Omoide/pull/87?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR ensures camera-capture validation errors remain visible by closing the fullscreen camera modal after validation, while preserving safe localized handling for unexpected submission failures.
- Extracts MIME normalization into a shared upload-validation helper.
- Adds regression coverage for valid and rejected camera captures in both contributor forms.
- Prevents local storage failures from turning successful submissions into failures.
- Keeps unexpected submission exceptions behind the generic localized error boundary.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| components/community/MessageForm.tsx | Uses shared media normalization, closes the camera after capture validation, safely handles storage failures, and preserves generic handling for thrown submission errors. |
| components/community/PostForm.tsx | Uses shared media normalization and prevents sender-name persistence failures from disrupting successful posts. |
| lib/validations/upload.ts | Centralizes MIME parameter stripping and case normalization without changing the forms’ established behavior. |
| __tests__/components/ContributorPromptButtons.test.tsx | Covers camera closure, visible validation errors, retry behavior, storage failures, and safe submission-error rendering. |
| __tests__/lib/upload-validation.test.ts | Covers MIME codec removal, casing and whitespace normalization, object preservation, and empty MIME types. |

</details>

<sub>Reviews (4): Last reviewed commit: ["テスト: normalizeMediaFile の MIME 正規化を検証"](https://github.com/hayato-shino05/omoide/commit/8b082b4d1e3e9a6d0db18dc12fe1eb0af55e3465) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59348246)</sub>

<!-- /greptile_comment -->