### PR TITLE
PostFormのメディア投稿をトランザクション経路へ統一

### DIFF
--- a/__tests__/components/ContributorPromptButtons.test.tsx
+++ b/__tests__/components/ContributorPromptButtons.test.tsx
@@ -166,7 +166,7 @@ describe('Contributor prompts', () => {
     })
     fireEvent.click(screen.getByRole('button', { name: 'postMessage' }))
 
-    await waitFor(() => expect(screen.getByText('postFailed')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText('投稿を送信できません')).toBeInTheDocument())
     expect(onSubmit).not.toHaveBeenCalled()
     expect(uploadCommunityMedia).not.toHaveBeenCalled()
   })

--- a/__tests__/components/ContributorPromptButtons.test.tsx
+++ b/__tests__/components/ContributorPromptButtons.test.tsx
@@ -49,6 +49,7 @@ vi.mock('@/lib/supabase/client', () => ({
 beforeEach(() => {
   sendMessage.mockReset()
   uploadCommunityMedia.mockReset()
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ data: {} }), { status: 201 })))
   localStorage.clear()
 })
 
@@ -90,8 +91,33 @@ describe('Contributor prompts', () => {
     expect(onSubmit).not.toHaveBeenCalled()
   })
 
-  it('uploads post media through the canonical community media helper', async () => {
-    uploadCommunityMedia.mockResolvedValue({ object_path: 'images/post.png' })
+  it('keeps text-only submission state when onSubmit returns false', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(false)
+    render(<PostForm onSubmit={onSubmit} />)
+
+    fireEvent.change(screen.getByPlaceholderText('yourName'), { target: { value: '花子' } })
+    fireEvent.change(screen.getByPlaceholderText('typeMessage'), { target: { value: '失敗する投稿' } })
+    fireEvent.click(screen.getByRole('button', { name: 'postMessage' }))
+
+    await waitFor(() => expect(screen.getByText('postFailed')).toBeInTheDocument())
+    expect(onSubmit).toHaveBeenCalledWith('花子', '失敗する投稿')
+    expect(uploadCommunityMedia).not.toHaveBeenCalled()
+  })
+
+  it('keeps text-only submission state when onSubmit rejects', async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error('submit failed'))
+    render(<PostForm onSubmit={onSubmit} />)
+
+    fireEvent.change(screen.getByPlaceholderText('yourName'), { target: { value: '花子' } })
+    fireEvent.change(screen.getByPlaceholderText('typeMessage'), { target: { value: '例外になる投稿' } })
+    fireEvent.click(screen.getByRole('button', { name: 'postMessage' }))
+
+    await waitFor(() => expect(screen.getByText('genericError')).toBeInTheDocument())
+    expect(onSubmit).toHaveBeenCalledWith('花子', '例外になる投稿')
+    expect(uploadCommunityMedia).not.toHaveBeenCalled()
+  })
+
+  it('submits post media through the transactional community route', async () => {
     const onSubmit = vi.fn().mockResolvedValue(true)
     render(<PostForm onSubmit={onSubmit} />)
 
@@ -101,12 +127,17 @@ describe('Contributor prompts', () => {
     fireEvent.change(document.querySelector('input[type="file"]') as HTMLInputElement, { target: { files: [file] } })
     fireEvent.click(screen.getByRole('button', { name: 'postMessage' }))
 
-    await waitFor(() => expect(uploadCommunityMedia).toHaveBeenCalledWith({ file, sender: '花子' }))
-    expect(onSubmit).toHaveBeenCalledWith('花子', 'おめでとう！', undefined, 'images/post.png')
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith('/api/community', expect.objectContaining({ method: 'POST' })))
+    const request = vi.mocked(fetch).mock.calls[0][1]
+    expect((request?.body as FormData).get('kind')).toBe('post')
+    expect((request?.body as FormData).get('sender')).toBe('花子')
+    expect((request?.body as FormData).get('content')).toBe('おめでとう！')
+    expect((request?.body as FormData).get('media')).toMatchObject({ name: file.name, type: file.type })
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(uploadCommunityMedia).not.toHaveBeenCalled()
   })
 
-  it('normalizes codec-qualified post media MIME types before upload', async () => {
-    uploadCommunityMedia.mockResolvedValue({ object_path: 'videos/post.webm' })
+  it('normalizes codec-qualified post media MIME types before the transactional route', async () => {
     const onSubmit = vi.fn().mockResolvedValue(true)
     render(<PostForm onSubmit={onSubmit} />)
 
@@ -116,9 +147,28 @@ describe('Contributor prompts', () => {
     fireEvent.change(document.querySelector('input[type="file"]') as HTMLInputElement, { target: { files: [file] } })
     fireEvent.click(screen.getByRole('button', { name: 'postMessage' }))
 
-    await waitFor(() => expect(uploadCommunityMedia).toHaveBeenCalled())
-    const uploadedFile = uploadCommunityMedia.mock.calls[0][0].file as File
-    expect(uploadedFile.type).toBe('video/webm')
+    await waitFor(() => expect(fetch).toHaveBeenCalled())
+    const request = vi.mocked(fetch).mock.calls[0][1]
+    expect((request?.body as FormData).get('media')).toBeInstanceOf(File)
+    expect(((request?.body as FormData).get('media') as File).type).toBe('video/webm')
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('does not invoke the legacy callback when transactional media submission fails', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: '投稿を送信できません' }), { status: 500 })))
+    const onSubmit = vi.fn().mockRejectedValue(new Error('legacy callback must not run'))
+    render(<PostForm onSubmit={onSubmit} />)
+
+    fireEvent.change(screen.getByPlaceholderText('yourName'), { target: { value: '花子' } })
+    fireEvent.change(screen.getByPlaceholderText('typeMessage'), { target: { value: '失敗する投稿' } })
+    fireEvent.change(document.querySelector('input[type="file"]') as HTMLInputElement, {
+      target: { files: [new File(['image'], 'post.png', { type: 'image/png' })] },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'postMessage' }))
+
+    await waitFor(() => expect(screen.getByText('postFailed')).toBeInTheDocument())
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(uploadCommunityMedia).not.toHaveBeenCalled()
   })
 
   it('closes the PostForm camera only after media validation succeeds', () => {

--- a/components/community/PostForm.tsx
+++ b/components/community/PostForm.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState, useRef, useEffect } from 'react'
-import { uploadCommunityMedia } from '@/lib/supabase/communityMedia'
 import { getMediaKind, normalizeMediaFile, validateCommunityMediaFile } from '@/lib/validations/upload'
 import { CameraCapture } from './CameraCapture'
 import { ContributorPromptButtons } from './ContributorPromptButtons'
@@ -66,16 +65,21 @@ export default function PostForm({ onSubmit }: PostFormProps) {
     if (fileInputRef.current) fileInputRef.current.value = ''
   }
 
-  const uploadFile = async (file: File): Promise<string | null> => {
-    try {
-      setUploadProgress(10)
-      const data = await uploadCommunityMedia({ file, sender: author })
-      setUploadProgress(100)
-      return data.object_path
-    } catch (err) {
-      console.error('Upload error:', err)
-      return null
-    }
+  const submitPostWithMedia = async (file: File): Promise<boolean> => {
+    const formData = new FormData()
+    formData.set('kind', 'post')
+    formData.set('sender', author.trim())
+    formData.set('content', content.trim())
+    formData.set('media', file, file.name)
+
+    setUploadProgress(10)
+    const response = await fetch('/api/community', { method: 'POST', body: formData })
+    setUploadProgress(100)
+    if (response.ok) return true
+
+    const errorBody = await response.json().catch(() => null) as { error?: string } | null
+    setError(errorBody?.error ?? t('postFailed'))
+    return false
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -87,19 +91,9 @@ export default function PostForm({ onSubmit }: PostFormProps) {
     setUploadProgress(0)
 
     try {
-      let mediaUrl: string | undefined
-
-      if (selectedFile) {
-        const url = await uploadFile(selectedFile)
-        if (!url) {
-          setError(t('uploadFileFailed'))
-          setSubmitting(false)
-          return
-        }
-        mediaUrl = url
-      }
-
-      const success = await onSubmit(author.trim(), content.trim(), undefined, mediaUrl)
+      const success = selectedFile
+        ? await submitPostWithMedia(selectedFile)
+        : await onSubmit(author.trim(), content.trim())
 
       if (success) {
         // 名前を共有ストレージに保存する（他のフォームと共用）

--- a/components/community/PostForm.tsx
+++ b/components/community/PostForm.tsx
@@ -105,7 +105,7 @@ export default function PostForm({ onSubmit }: PostFormProps) {
         // 投稿者名は保持し、本文のみクリアする
         setContent('')
         removeFile()
-      } else {
+      } else if (!selectedFile) {
         setError(t('postFailed'))
       }
     } catch {


### PR DESCRIPTION
## 概要
- PostFormのメディア付き投稿を `/api/community` のサーバー側トランザクション経路へ統一
- text-only投稿では既存の `onSubmit` 契約を維持
- false / reject / route failure の回帰テストを追加

## 検証
- `npm test -- --run __tests__/components/ContributorPromptButtons.test.tsx __tests__/api/community-route.test.ts`
- `npm run typecheck`
- `npm run lint -- components/community/PostForm.tsx __tests__/components/ContributorPromptButtons.test.tsx`
- `git diff --check`

Refs #2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes PostForm media submissions through the `/api/community` transactional endpoint instead of the direct upload helper, so media posts are saved atomically with the post.

- Text-only posts keep using the existing `onSubmit` contract; media posts now skip `onSubmit` and send a `FormData` payload.
- Failed transactional requests show the server's error message, and media failures no longer fall back to the legacy callback.
- Adds regression tests for `onSubmit` returning false, `onSubmit` rejecting, MIME normalization, and route failure.

<sup>Written for commit 3660a8fe691f9b6c0cc7f8b99484bda27889a3c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hayato-shino05/Omoide/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR routes media-bearing PostForm submissions through the transactional `/api/community` endpoint while preserving the existing callback contract for text-only posts.
- Builds and submits media posts as `FormData`.
- Preserves server-provided errors when transactional submission fails.
- Adds regression coverage for callback failures, rejected submissions, MIME normalization, and route failures.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| components/community/PostForm.tsx | Media submissions now use the transactional API route, while the failure branch correctly preserves route-provided diagnostics. |
| __tests__/components/ContributorPromptButtons.test.tsx | Regression tests cover text-only callback failures, transactional media submission, MIME normalization, and preservation of route errors. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Submit PostForm] --> B{Media selected?}
  B -- No --> C[Call existing onSubmit callback]
  B -- Yes --> D[POST FormData to /api/community]
  C --> E{Successful?}
  D --> E
  E -- Yes --> F[Clear content and media]
  E -- No, text-only --> G[Show localized postFailed]
  E -- No, media response --> H[Preserve server error]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["PostFormのサーバーエラー表示を維持"](https://github.com/hayato-shino05/omoide/commit/3660a8fe691f9b6c0cc7f8b99484bda27889a3c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59358844)</sub>

<!-- /greptile_comment -->