### PR TITLE
feat: add community media-only upload route

### DIFF
--- a/__tests__/api/community-media-route.test.ts
+++ b/__tests__/api/community-media-route.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const server = vi.hoisted(() => ({ createServiceClient: vi.fn() }))
+vi.mock('@/lib/time-capsule/server', () => server)
+
+import { POST } from '@/app/api/community/media/route'
+
+function makeClient(insertResult: { data: Record<string, unknown> | null; error: Error | null } = { data: { id: 1, object_path: 'images/id.png' }, error: null }) {
+  const remove = vi.fn().mockResolvedValue({ error: null })
+  const upload = vi.fn().mockResolvedValue({ error: null })
+  const single = vi.fn().mockResolvedValue(insertResult)
+  const client = {
+    storage: { from: vi.fn(() => ({ upload, remove, getPublicUrl: () => ({ data: { publicUrl: 'https://example.com/media' } }) })) },
+    from: vi.fn(() => ({ insert: vi.fn(() => ({ select: vi.fn(() => ({ single })) })) })),
+  }
+  server.createServiceClient.mockReturnValue(client)
+  return { client, upload, remove, single }
+}
+
+function request(fields: Record<string, string>, file?: File) {
+  const body = new FormData()
+  Object.entries(fields).forEach(([key, value]) => body.set(key, value))
+  if (file) body.set('file', file)
+  return { formData: async () => body } as unknown as NextRequest
+}
+
+beforeEach(() => vi.resetAllMocks())
+
+describe('POST /api/community/media', () => {
+  it('validates before creating a service client', async () => {
+    makeClient()
+    const response = await POST(request({ sender: '花子' }, new File(['x'], 'bad.exe', { type: 'application/octet-stream' })))
+
+    expect(response.status).toBe(400)
+    expect(server.createServiceClient).not.toHaveBeenCalled()
+  })
+
+  it('uploads and inserts media, returning its public URL', async () => {
+    const { client, upload } = makeClient()
+    const response = await POST(request({ sender: '花子', description: 'ケーキ' }, new File(['image'], 'cake.png', { type: 'image/png' })))
+
+    expect(response.status).toBe(201)
+    expect(upload).toHaveBeenCalledWith(expect.stringMatching(/^images\//), expect.any(File), { contentType: 'image/png', upsert: false })
+    expect(client.from).toHaveBeenCalledWith('media_submissions')
+    await expect(response.json()).resolves.toEqual({ data: expect.objectContaining({ id: 1, media_url: 'https://example.com/media' }) })
+  })
+
+  it('cleans up after a definite metadata insert failure', async () => {
+    const insertError = new Error('insert failed')
+    const { upload, remove } = makeClient({ data: null, error: insertError })
+    const response = await POST(request({ sender: '花子' }, new File(['image'], 'cake.png', { type: 'image/png' })))
+
+    expect(response.status).toBe(500)
+    expect(remove).toHaveBeenCalledWith([upload.mock.calls[0][0]])
+  })
+
+  it('does not clean up when metadata transport rejects', async () => {
+    const { client, remove } = makeClient()
+    client.from.mockImplementation(() => ({ insert: vi.fn(() => ({ select: vi.fn(() => ({ single: vi.fn().mockRejectedValue(new Error('transport')) })) })) }))
+    const response = await POST(request({ sender: '花子' }, new File(['image'], 'cake.png', { type: 'image/png' })))
+
+    expect(response.status).toBe(500)
+    expect(remove).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/api/community-media-route.test.ts
+++ b/__tests__/api/community-media-route.test.ts
@@ -55,6 +55,25 @@ describe('POST /api/community/media', () => {
     expect(remove).toHaveBeenCalledWith([upload.mock.calls[0][0]])
   })
 
+  it('logs a cleanup error returned by storage', async () => {
+    const cleanupError = new Error('remove failed')
+    const { remove } = makeClient({ data: null, error: new Error('insert failed') })
+    remove.mockResolvedValueOnce({ error: cleanupError })
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    await POST(request({ sender: '花子' }, new File(['image'], 'cake.png', { type: 'image/png' })))
+
+    expect(logSpy).toHaveBeenCalledWith('Community media cleanup failed', 'remove failed')
+  })
+
+  it('cleans up when metadata data is null without an insert error', async () => {
+    const { upload, remove } = makeClient({ data: null, error: null })
+    const response = await POST(request({ sender: '花子' }, new File(['image'], 'cake.png', { type: 'image/png' })))
+
+    expect(response.status).toBe(500)
+    expect(remove).toHaveBeenCalledWith([upload.mock.calls[0][0]])
+  })
+
   it('does not clean up when metadata transport rejects', async () => {
     const { client, remove } = makeClient()
     client.from.mockImplementation(() => ({ insert: vi.fn(() => ({ select: vi.fn(() => ({ single: vi.fn().mockRejectedValue(new Error('transport')) })) })) }))

--- a/__tests__/lib/community-media.test.ts
+++ b/__tests__/lib/community-media.test.ts
@@ -21,12 +21,19 @@ describe('uploadCommunityMedia', () => {
   })
 
   it('normalizes MIME parameters before transport', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ data: { object_path: 'videos/id.mp4', media_url: 'https://example.com/video' } }), { status: 201 }))
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ data: { id: 1, object_path: 'videos/id.mp4', media_url: 'https://example.com/video' } }), { status: 201 }))
 
     await uploadCommunityMedia({ file: new File(['video'], 'clip.mp4', { type: 'video/mp4; codecs=avc1' }), sender: '花子' })
 
     const body = vi.mocked(fetch).mock.calls[0]?.[1]?.body as FormData
     expect((body.get('file') as File).type).toBe('video/mp4')
+  })
+
+  it('rejects responses missing required media fields', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ data: { object_path: 'images/id.png' } }), { status: 201 }))
+
+    await expect(uploadCommunityMedia({ file: new File(['image'], 'cake.png', { type: 'image/png' }), sender: '花子' }))
+      .rejects.toThrow('メディア応答が無効です')
   })
 
   it('maps endpoint errors without exposing transport details', async () => {

--- a/__tests__/lib/community-media.test.ts
+++ b/__tests__/lib/community-media.test.ts
@@ -1,53 +1,38 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const upload = vi.fn().mockResolvedValue({ error: null })
-const remove = vi.fn().mockResolvedValue({ error: null })
-const insert = vi.fn().mockReturnValue({
-  select: vi.fn().mockReturnValue({ single: vi.fn().mockResolvedValue({ data: { id: 1 }, error: null }) }),
-})
-
-vi.mock('@/lib/supabase/client', () => ({
-  getSupabase: () => ({
-    storage: { from: () => ({ upload, remove, getPublicUrl: () => ({ data: { publicUrl: 'https://example.com/media' } }) }) },
-    from: () => ({ insert }),
-  }),
-}))
-
 import { uploadCommunityMedia } from '@/lib/supabase/communityMedia'
 
 describe('uploadCommunityMedia', () => {
-  beforeEach(() => {
-    upload.mockClear()
-    remove.mockClear()
-    insert.mockClear()
-  })
+  beforeEach(() => vi.restoreAllMocks())
 
-  it('uploads an allowed file and records its object path', async () => {
+  it('uploads an allowed file through the media endpoint', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+      data: { id: 1, object_path: 'images/id.png', media_url: 'https://example.com/media' },
+    }), { status: 201, headers: { 'content-type': 'application/json' } }))
     const file = new File(['image'], 'cake.png', { type: 'image/png' })
 
-    await uploadCommunityMedia({ file, sender: '花子' })
+    const result = await uploadCommunityMedia({ file, sender: '花子' })
 
-    expect(upload).toHaveBeenCalledWith(expect.stringMatching(/^images\//), file, {
-      contentType: 'image/png',
-      upsert: false,
-    })
-    expect(insert).toHaveBeenCalledWith(expect.objectContaining({
-      sender: '花子',
-      media_kind: 'image',
-      original_name: 'cake.png',
-    }))
+    expect(fetchMock).toHaveBeenCalledWith('/api/community/media', expect.objectContaining({ method: 'POST', body: expect.any(FormData) }))
+    const body = fetchMock.mock.calls[0][1]?.body as FormData
+    expect(body.get('sender')).toBe('花子')
+    expect(body.get('file')).toBeInstanceOf(File)
+    expect(result).toEqual(expect.objectContaining({ object_path: 'images/id.png' }))
   })
 
-  it('removes the object when metadata insert fails', async () => {
-    const insertError = new Error('insert failed')
-    insert.mockReturnValueOnce({
-      select: vi.fn().mockReturnValue({ single: vi.fn().mockResolvedValue({ data: null, error: insertError }) }),
-    })
+  it('normalizes MIME parameters before transport', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ data: { object_path: 'videos/id.mp4', media_url: 'https://example.com/video' } }), { status: 201 }))
+
+    await uploadCommunityMedia({ file: new File(['video'], 'clip.mp4', { type: 'video/mp4; codecs=avc1' }), sender: '花子' })
+
+    const body = vi.mocked(fetch).mock.calls[0]?.[1]?.body as FormData
+    expect((body.get('file') as File).type).toBe('video/mp4')
+  })
+
+  it('maps endpoint errors without exposing transport details', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ error: 'メディア内容が無効です' }), { status: 400 }))
 
     await expect(uploadCommunityMedia({ file: new File(['image'], 'cake.png', { type: 'image/png' }), sender: '花子' }))
-      .rejects.toBe(insertError)
-    const uploadedPath = upload.mock.calls[0]?.[0]
-    expect(uploadedPath).toEqual(expect.stringMatching(/^images\//))
-    expect(remove).toHaveBeenCalledWith([uploadedPath])
+      .rejects.toThrow('メディア内容が無効です')
   })
 })

--- a/app/api/community/media/route.ts
+++ b/app/api/community/media/route.ts
@@ -73,13 +73,17 @@ export async function POST(request: NextRequest) {
       .select()
       .single()
 
-    if (insertError) {
-      try {
-        await supabase.storage.from('community-media').remove([objectPath])
-      } catch (cleanupError) {
-        console.error('Community media cleanup failed', cleanupError instanceof Error ? cleanupError.message : 'unknown error')
+    const hasUsableMediaRow = data !== null
+      && typeof data === 'object'
+      && typeof data.id === 'number'
+      && typeof data.object_path === 'string'
+    if (insertError || !hasUsableMediaRow) {
+      const { error: cleanupError } = await supabase.storage.from('community-media').remove([objectPath])
+      if (cleanupError) {
+        console.error('Community media cleanup failed', cleanupError.message)
       }
-      throw insertError
+      if (insertError) throw insertError
+      throw new Error('invalid media metadata')
     }
 
     const { data: urlData } = supabase.storage.from('community-media').getPublicUrl(objectPath)

--- a/app/api/community/media/route.ts
+++ b/app/api/community/media/route.ts
@@ -18,6 +18,15 @@ function parseOptionalText(formData: FormData, key: string, maxLength: number): 
   return normalized.length <= maxLength ? normalized : undefined
 }
 
+function isUsableMediaRow(value: unknown): value is { id: number; object_path: string } {
+  return typeof value === 'object'
+    && value !== null
+    && 'id' in value
+    && typeof value.id === 'number'
+    && 'object_path' in value
+    && typeof value.object_path === 'string'
+}
+
 function parseFile(formData: FormData): File | null {
   const value = formData.get('file')
   if (!value || typeof value !== 'object' || typeof (value as Blob).size !== 'number' || typeof (value as File).name !== 'string') return null
@@ -73,11 +82,7 @@ export async function POST(request: NextRequest) {
       .select()
       .single()
 
-    const hasUsableMediaRow = data !== null
-      && typeof data === 'object'
-      && typeof data.id === 'number'
-      && typeof data.object_path === 'string'
-    if (insertError || !hasUsableMediaRow) {
+    if (insertError || !isUsableMediaRow(data)) {
       const { error: cleanupError } = await supabase.storage.from('community-media').remove([objectPath])
       if (cleanupError) {
         console.error('Community media cleanup failed', cleanupError.message)

--- a/app/api/community/media/route.ts
+++ b/app/api/community/media/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/time-capsule/server'
+import { getMediaKind, normalizeMediaFile, validateCommunityMediaFile } from '@/lib/validations/upload'
+
+function parseText(formData: FormData, key: string, maxLength: number): string | null {
+  const value = formData.get(key)
+  if (typeof value !== 'string') return null
+  const normalized = value.trim()
+  return normalized && normalized.length <= maxLength ? normalized : null
+}
+
+function parseOptionalText(formData: FormData, key: string, maxLength: number): string | null | undefined {
+  const value = formData.get(key)
+  if (value === null) return null
+  if (typeof value !== 'string') return undefined
+  const normalized = value.trim()
+  if (!normalized) return null
+  return normalized.length <= maxLength ? normalized : undefined
+}
+
+function parseFile(formData: FormData): File | null {
+  const value = formData.get('file')
+  if (!value || typeof value !== 'object' || typeof (value as Blob).size !== 'number' || typeof (value as File).name !== 'string') return null
+  if ((value as File).size === 0 && !(value as File).name) return null
+  const file = normalizeMediaFile(value as File)
+  const filename = file.name.trim()
+  if (!filename || filename.length > 255 || /[\\/\p{Cc}]/u.test(filename)) return null
+  return file
+}
+
+export async function POST(request: NextRequest) {
+  let formData: FormData
+  try {
+    formData = await request.formData()
+  } catch {
+    return NextResponse.json({ error: 'メディア内容が無効です' }, { status: 400 })
+  }
+
+  const file = parseFile(formData)
+  const sender = parseText(formData, 'sender', 100)
+  const birthdayPerson = parseOptionalText(formData, 'birthdayPerson', 100)
+  const description = parseOptionalText(formData, 'description', 1000)
+  if (!file || !sender || birthdayPerson === undefined || description === undefined) {
+    return NextResponse.json({ error: 'メディア内容が無効です' }, { status: 400 })
+  }
+
+  const validation = validateCommunityMediaFile(file)
+  const mediaKind = getMediaKind(file.type)
+  if (!validation.valid || !mediaKind) {
+    return NextResponse.json({ error: validation.valid ? 'サポートされていないファイル形式です' : validation.error }, { status: 400 })
+  }
+
+  const objectPath = `${mediaKind}s/${crypto.randomUUID()}.${file.name.split('.').pop()?.toLowerCase().replace(/[^a-z0-9]/g, '') || 'bin'}`
+  try {
+    const supabase = createServiceClient()
+    const { error: uploadError } = await supabase.storage
+      .from('community-media')
+      .upload(objectPath, file, { contentType: file.type, upsert: false })
+    if (uploadError) throw uploadError
+
+    const { data, error: insertError } = await supabase
+      .from('media_submissions')
+      .insert({
+        sender,
+        object_path: objectPath,
+        media_kind: mediaKind,
+        mime_type: file.type,
+        original_name: file.name.trim(),
+        size_bytes: file.size,
+        birthday_person: birthdayPerson,
+        description,
+      })
+      .select()
+      .single()
+
+    if (insertError) {
+      try {
+        await supabase.storage.from('community-media').remove([objectPath])
+      } catch (cleanupError) {
+        console.error('Community media cleanup failed', cleanupError instanceof Error ? cleanupError.message : 'unknown error')
+      }
+      throw insertError
+    }
+
+    const { data: urlData } = supabase.storage.from('community-media').getPublicUrl(objectPath)
+    return NextResponse.json({ data: { ...data, media_url: urlData.publicUrl } }, { status: 201 })
+  } catch {
+    return NextResponse.json({ error: 'メディアをアップロードできません' }, { status: 500 })
+  }
+}

--- a/lib/supabase/communityMedia.ts
+++ b/lib/supabase/communityMedia.ts
@@ -75,7 +75,10 @@ export async function uploadCommunityMedia({
   }
 
   const data = payload && typeof payload === 'object' && 'data' in payload ? payload.data : null
-  if (!data || typeof data !== 'object' || !('object_path' in data) || typeof data.object_path !== 'string') {
+  if (!data || typeof data !== 'object'
+    || !('id' in data) || typeof data.id !== 'number'
+    || !('object_path' in data) || typeof data.object_path !== 'string'
+    || !('media_url' in data) || typeof data.media_url !== 'string') {
     throw new Error('メディア応答が無効です')
   }
   return data as CommunityMediaSubmission

--- a/lib/supabase/communityMedia.ts
+++ b/lib/supabase/communityMedia.ts
@@ -1,5 +1,4 @@
-import { getSupabase } from '@/lib/supabase/client'
-import { getMediaKind, validateCommunityMediaFile } from '@/lib/validations/upload'
+import { getMediaKind, normalizeMediaFile, validateCommunityMediaFile } from '@/lib/validations/upload'
 
 interface CommunityMediaUploadInput {
   file: File
@@ -8,14 +7,27 @@ interface CommunityMediaUploadInput {
   description?: string
 }
 
+export interface CommunityMediaSubmission {
+  id: number
+  sender: string
+  object_path: string
+  media_kind: 'image' | 'video' | 'audio'
+  original_name: string
+  size_bytes: number
+  description: string | null
+  created_at: string
+  media_url: string
+}
+
 export async function uploadCommunityMedia({
   file,
   sender,
   birthdayPerson,
   description,
-}: CommunityMediaUploadInput) {
-  const validation = validateCommunityMediaFile(file)
-  const mediaKind = getMediaKind(file.type)
+}: CommunityMediaUploadInput): Promise<CommunityMediaSubmission> {
+  const normalizedFile = normalizeMediaFile(file)
+  const validation = validateCommunityMediaFile(normalizedFile)
+  const mediaKind = getMediaKind(normalizedFile.type)
 
   if (!validation.valid || !mediaKind) {
     throw new Error(validation.valid ? 'サポートされていないファイル形式です' : validation.error)
@@ -36,45 +48,35 @@ export async function uploadCommunityMedia({
     throw new Error('説明が長すぎます')
   }
 
-  const normalizedOriginalName = file.name.trim()
-  if (!normalizedOriginalName || normalizedOriginalName.length > 255) {
+  const normalizedOriginalName = normalizedFile.name.trim()
+  if (!normalizedOriginalName || normalizedOriginalName.length > 255 || /[\\/\p{Cc}]/u.test(normalizedOriginalName)) {
     throw new Error('ファイル名が無効です')
   }
 
-  const extension = normalizedOriginalName.split('.').pop()?.toLowerCase().replace(/[^a-z0-9]/g, '') || 'bin'
-  const objectPath = `${mediaKind}s/${crypto.randomUUID()}.${extension}`
-  const supabase = getSupabase()
-  const { error: uploadError } = await supabase.storage
-    .from('community-media')
-    .upload(objectPath, file, { contentType: file.type, upsert: false })
+  const formData = new FormData()
+  formData.set('file', normalizedFile, normalizedOriginalName)
+  formData.set('sender', normalizedSender)
+  if (normalizedBirthdayPerson) formData.set('birthdayPerson', normalizedBirthdayPerson)
+  if (normalizedDescription) formData.set('description', normalizedDescription)
 
-  if (uploadError) throw uploadError
-
-  const { data, error: insertError } = await supabase
-    .from('media_submissions')
-    .insert({
-      sender: normalizedSender,
-      object_path: objectPath,
-      media_kind: mediaKind,
-      mime_type: file.type,
-      original_name: normalizedOriginalName,
-      size_bytes: file.size,
-      birthday_person: normalizedBirthdayPerson,
-      description: normalizedDescription,
-    })
-    .select()
-    .single()
-
-  if (insertError) {
-    try {
-      const { error: cleanupError } = await supabase.storage.from('community-media').remove([objectPath])
-      if (cleanupError) console.error('Failed to clean up uploaded community media:', cleanupError)
-    } catch (cleanupError) {
-      console.error('Failed to clean up uploaded community media:', cleanupError)
-    }
-    throw insertError
+  const response = await fetch('/api/community/media', { method: 'POST', body: formData })
+  let payload: unknown
+  try {
+    payload = await response.json()
+  } catch {
+    throw new Error('メディアをアップロードできません')
   }
 
-  const { data: urlData } = supabase.storage.from('community-media').getPublicUrl(objectPath)
-  return { ...data, media_url: urlData.publicUrl }
+  if (!response.ok) {
+    const error = payload && typeof payload === 'object' && 'error' in payload && typeof payload.error === 'string'
+      ? payload.error
+      : 'メディアをアップロードできません'
+    throw new Error(error)
+  }
+
+  const data = payload && typeof payload === 'object' && 'data' in payload ? payload.data : null
+  if (!data || typeof data !== 'object' || !('object_path' in data) || typeof data.object_path !== 'string') {
+    throw new Error('メディア応答が無効です')
+  }
+  return data as CommunityMediaSubmission
 }

--- a/lib/validations/upload.ts
+++ b/lib/validations/upload.ts
@@ -16,6 +16,12 @@ const COMMUNITY_MEDIA_TYPES = new Set([
 
 export type CommunityMediaKind = 'image' | 'video' | 'audio'
 
+export function normalizeMediaFile(file: File): File {
+  const mimeType = file.type.split(';', 1)[0].trim().toLowerCase()
+  if (mimeType === file.type) return file
+  return new File([file], file.name, { type: mimeType, lastModified: file.lastModified })
+}
+
 export function getMediaKind(mimeType: string): CommunityMediaKind | null {
   if (mimeType.startsWith('image/')) return 'image'
   if (mimeType.startsWith('video/')) return 'video'


### PR DESCRIPTION
## Summary
- Add `POST /api/community/media` for validated media-only multipart uploads.
- Keep service-role storage and metadata writes server-side with cleanup after definite insert failures.
- Route `uploadCommunityMedia` through the endpoint while preserving the caller return contract.

## Acceptance criteria
- [x] Accept `file`, `sender`, optional `birthdayPerson`, and optional `description`.
- [x] Normalize and validate filename, MIME type, size, and text fields at the route boundary.
- [x] Return `201 { data: { ...media row, media_url } }` on success.
- [x] Return safe 400/500 errors and clean up uploaded objects only after definite insert failure.
- [x] Preserve existing text/community transaction behavior.

## Implementation
- Added canonical `normalizeMediaFile` to the upload validation module.
- Added focused route and client tests for validation, success, cleanup, and transport uncertainty.

## Verification
- `npm test -- --run __tests__/api/community-route.test.ts __tests__/api/community-media-route.test.ts __tests__/lib/community-media.test.ts __tests__/components/ContributorPromptButtons.test.tsx` (26 passed)
- `npm run typecheck` passed.
- `npm run lint -- app/api/community/media/route.ts lib/supabase/communityMedia.ts lib/validations/upload.ts __tests__/api/community-media-route.test.ts __tests__/lib/community-media.test.ts` passed.
- `git diff --check` passed.

## Test plan
- [x] Focused media route tests
- [x] Existing community route regression tests
- [x] Client transport and MIME normalization tests

## References
Refs #2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a media-only upload endpoint `POST /api/community/media` so community uploads no longer hit Supabase directly from the client; `uploadCommunityMedia` now calls the route and keeps its existing return contract.

- Validates filename, MIME type, size, and text fields at the route boundary and returns safe 400/500 errors.
- Cleans up uploaded objects only after a definite metadata insert failure, not when the metadata transport rejects.
- Normalizes MIME parameters (for example, strips `; codecs=...`) before validation and transport.
- Validates media metadata shape on both the route and client, and surfaces endpoint errors without exposing transport details.
- Moves storage and metadata writes server-side under the service-role client as the media-only upload step for the runtime media-limit work in issue #2.

<sup>Written for commit ba7beece08dfadb7e9a7b791ae3e718cd19d16f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hayato-shino05/Omoide/pull/89?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

